### PR TITLE
auth - Added auth for sentence-plan-api calls

### DIFF
--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -21,15 +21,22 @@ import SentencePlanApiClient from './sentencePlanApiClient'
 
 type RestClientBuilder<T> = (token: string) => T
 
-export const dataAccess = () => ({
-  applicationInfo,
-  hmppsAuthClient: new HmppsAuthClient(
+export const dataAccess = () => {
+  const hmppsAuthClient = new HmppsAuthClient(
     config.redis.enabled ? new RedisTokenStore(createRedisClient()) : new InMemoryTokenStore(),
-  ),
-  manageUsersApiClient: new ManageUsersApiClient(),
-  sentencePlanApiClient: new SentencePlanApiClient(),
-  hmppsAuditClient: new HmppsAuditClient(config.sqs.audit),
-})
+  )
+  const manageUsersApiClient = new ManageUsersApiClient()
+  const sentencePlanApiClient = new SentencePlanApiClient(hmppsAuthClient)
+  const hmppsAuditClient = new HmppsAuditClient(config.sqs.audit)
+
+  return {
+    applicationInfo,
+    hmppsAuthClient,
+    manageUsersApiClient,
+    sentencePlanApiClient,
+    hmppsAuditClient,
+  }
+}
 
 export type DataAccess = ReturnType<typeof dataAccess>
 

--- a/server/data/sentencePlanApiClient.test.ts
+++ b/server/data/sentencePlanApiClient.test.ts
@@ -4,13 +4,21 @@ import SentencePlanApiClient from './sentencePlanApiClient'
 import testReferenceData from '../testutils/data/referenceData'
 import { testGoal, testNewGoal } from '../testutils/data/goalData'
 import { testNewStep, testStep } from '../testutils/data/stepData'
+import HmppsAuthClient from './hmppsAuthClient'
+
+jest.mock('./hmppsAuthClient', () => {
+  return jest.fn().mockImplementation(() => ({
+    getSystemClientToken: jest.fn().mockResolvedValue('a-mock-token'),
+  }))
+})
 
 describe('SentencePlanApiClient', () => {
   let client: SentencePlanApiClient
   let fakeApi: nock.Scope
+  const hmppsAuthClient: HmppsAuthClient = new HmppsAuthClient(null)
 
   beforeEach(() => {
-    client = new SentencePlanApiClient()
+    client = new SentencePlanApiClient(hmppsAuthClient)
     fakeApi = nock(config.apis.sentencePlanApi.url)
   })
 

--- a/server/data/sentencePlanApiClient.ts
+++ b/server/data/sentencePlanApiClient.ts
@@ -7,22 +7,25 @@ import { NewStep } from '../interfaces/NewStepType'
 import { Goal } from '../interfaces/GoalType'
 import { Step } from '../interfaces/StepType'
 import { roSHData } from '../testutils/data/roshData'
+import HmppsAuthClient from './hmppsAuthClient'
 
 export default class SentencePlanApiClient {
-  constructor() {}
+  constructor(private readonly authClient: HmppsAuthClient) {}
 
-  private static restClient(): RestClient {
-    return new RestClient('Sentence Plan Api Client', config.apis.sentencePlanApi, null)
+  private static restClient(token?: string): RestClient {
+    return new RestClient('Sentence Plan Api Client', config.apis.sentencePlanApi, token)
   }
 
-  getHelloWorld(world: string): Promise<string> {
+  async getHelloWorld(world: string): Promise<string> {
     logger.info('Calling hello world service')
-    return SentencePlanApiClient.restClient().get<string>({ path: `/hello/${world}` })
+    const token = await this.authClient.getSystemClientToken()
+    return SentencePlanApiClient.restClient(token).get<string>({ path: `/hello/${world}` })
   }
 
-  getAllReferenceData(): Promise<ReferenceData> {
+  async getAllReferenceData(): Promise<ReferenceData> {
     logger.info('Getting question reference data')
-    return SentencePlanApiClient.restClient().get<ReferenceData>({ path: `/question-reference-data` })
+    const token = await this.authClient.getSystemClientToken()
+    return SentencePlanApiClient.restClient(token).get<ReferenceData>({ path: `/question-reference-data` })
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -60,13 +63,15 @@ export default class SentencePlanApiClient {
     }
   }
 
-  saveGoal(goal: NewGoal) {
+  async saveGoal(goal: NewGoal) {
     logger.info('Saving goal data')
-    return SentencePlanApiClient.restClient().post<Goal>({ path: `/goals`, data: goal })
+    const token = await this.authClient.getSystemClientToken()
+    return SentencePlanApiClient.restClient(token).post<Goal>({ path: `/goals`, data: goal })
   }
 
-  saveSteps(steps: NewStep[], parentGoalId: string) {
+  async saveSteps(steps: NewStep[], parentGoalId: string) {
     logger.info('Saving multiple steps')
-    return SentencePlanApiClient.restClient().post<Step[]>({ path: `/goals/${parentGoalId}/steps`, data: steps })
+    const token = await this.authClient.getSystemClientToken()
+    return SentencePlanApiClient.restClient(token).post<Step[]>({ path: `/goals/${parentGoalId}/steps`, data: steps })
   }
 }


### PR DESCRIPTION
- Added calls to hmpps-auth for client credentials token
- Use client credentials token for communicating with sentence-plan API now that it's endpoints require auth

**Note: Make sure to set env values for `SYSTEM_CLIENT_ID`, `SYSTEM_CLIENT_SECRET` and `HMPPS_AUTH_URL` on your local dev environment from now on**