### PR TITLE
SP2-458 Refactor frontend naming schema references from 'id' to 'uuid' where appropriate

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ And then, to build the assets and start the app with nodemon:
 
 ### Run tests
 
-`npm run test`
+`npm test`
 
 ### Running integration tests
 

--- a/server/@types/StepType.ts
+++ b/server/@types/StepType.ts
@@ -1,7 +1,7 @@
 export type Step = {
   id: number
   uuid: string
-  relatedGoalId: string
+  relatedGoalUuid: string
   description: string
   actor: string
   creationDate: string

--- a/server/data/sentencePlanApiClient.test.ts
+++ b/server/data/sentencePlanApiClient.test.ts
@@ -48,10 +48,10 @@ describe('SentencePlanApiClient', () => {
 
   describe('saveSteps', () => {
     it('should save steps data via the API', async () => {
-      const parentGoalId = testGoal.uuid
-      fakeApi.post(`/goals/${parentGoalId}/steps`, [testNewStep]).reply(200, testStep)
+      const parentGoalUuid = testGoal.uuid
+      fakeApi.post(`/goals/${parentGoalUuid}/steps`, [testNewStep]).reply(200, testStep)
 
-      const result = await client.saveSteps([testNewStep], parentGoalId)
+      const result = await client.saveSteps([testNewStep], parentGoalUuid)
 
       expect(result).toEqual(testStep)
     })

--- a/server/data/sentencePlanApiClient.ts
+++ b/server/data/sentencePlanApiClient.ts
@@ -61,9 +61,12 @@ export default class SentencePlanApiClient {
     return SentencePlanApiClient.restClient(token).post<Goal>({ path: `/goals`, data: goal })
   }
 
-  async saveSteps(steps: NewStep[], parentGoalId: string) {
+  async saveSteps(steps: NewStep[], parentGoalUuidId: string) {
     logger.info('Saving multiple steps')
     const token = await this.authClient.getSystemClientToken()
-    return SentencePlanApiClient.restClient(token).post<Step[]>({ path: `/goals/${parentGoalId}/steps`, data: steps })
+    return SentencePlanApiClient.restClient(token).post<Step[]>({
+      path: `/goals/${parentGoalUuidId}/steps`,
+      data: steps,
+    })
   }
 }

--- a/server/services/sentence-plan/stepsService.ts
+++ b/server/services/sentence-plan/stepsService.ts
@@ -4,7 +4,7 @@ import { NewStep } from '../../@types/NewStepType'
 export default class StepService {
   constructor(private readonly sentencePlanApiClient: SentencePlanApiClient) {}
 
-  saveSteps(steps: NewStep[], parentGoalId: string) {
-    return this.sentencePlanApiClient.saveSteps(steps, parentGoalId)
+  saveSteps(steps: NewStep[], parentGoalUuid: string) {
+    return this.sentencePlanApiClient.saveSteps(steps, parentGoalUuid)
   }
 }

--- a/server/testutils/data/stepData.ts
+++ b/server/testutils/data/stepData.ts
@@ -10,7 +10,7 @@ export const testNewStep: NewStep = {
 export const testStep: Step = {
   id: 123,
   uuid: 'a-un1qu3-t3st-Uu1d',
-  relatedGoalId: testGoal.uuid,
+  relatedGoalUuid: testGoal.uuid,
   creationDate: new Date().toISOString().substring(0, 10),
   ...testNewStep,
 }


### PR DESCRIPTION
This is the counterpart PR to https://github.com/ministryofjustice/hmpps-sentence-plan/pull/31

As well as renaming references from "id" to "uuid" it also includes a small correction to the README for running tests.