### PR TITLE
SP2-440 - Add Plan Service

### DIFF
--- a/server/@types/PlanType.ts
+++ b/server/@types/PlanType.ts
@@ -1,0 +1,6 @@
+export type PlanType = {
+  uuid: string
+  status: string
+  createdAt: Date
+  updatedAt: Date
+}

--- a/server/data/sentencePlanApiClient.test.ts
+++ b/server/data/sentencePlanApiClient.test.ts
@@ -5,6 +5,7 @@ import testReferenceData from '../testutils/data/referenceData'
 import { testGoal, testNewGoal } from '../testutils/data/goalData'
 import { testNewStep, testStep } from '../testutils/data/stepData'
 import HmppsAuthClient from './hmppsAuthClient'
+import testPlan from '../testutils/data/planData'
 
 jest.mock('./hmppsAuthClient', () => {
   return jest.fn().mockImplementation(() => ({
@@ -54,6 +55,36 @@ describe('SentencePlanApiClient', () => {
       const result = await client.saveSteps([testNewStep], parentGoalUuid)
 
       expect(result).toEqual(testStep)
+    })
+  })
+
+  describe('getPlanByUuid', () => {
+    it('should fetch a plan by its UUID', async () => {
+      const mockTestPlan = testPlan
+      fakeApi.get(`/plan/123`).reply(200, mockTestPlan)
+
+      const result = await client.getPlanByUuid('123')
+
+      expect(result).toEqual({
+        ...mockTestPlan,
+        createdAt: mockTestPlan.createdAt.toISOString(),
+        updatedAt: mockTestPlan.updatedAt.toISOString(),
+      })
+    })
+  })
+
+  describe('getPlanByOasysAssessmentPk', () => {
+    it('should fetch a plan by its related OASys Assessment PK', async () => {
+      const mockTestPlan = testPlan
+      fakeApi.get(`/oasys/123`).reply(200, mockTestPlan)
+
+      const result = await client.getPlanByOasysAssessmentPk('123')
+
+      expect(result).toEqual({
+        ...mockTestPlan,
+        createdAt: mockTestPlan.createdAt.toISOString(),
+        updatedAt: mockTestPlan.updatedAt.toISOString(),
+      })
     })
   })
 })

--- a/server/data/sentencePlanApiClient.ts
+++ b/server/data/sentencePlanApiClient.ts
@@ -9,6 +9,7 @@ import { Step } from '../@types/StepType'
 import HmppsAuthClient from './hmppsAuthClient'
 import { Person } from '../@types/Person'
 import { RoshData } from '../@types/Rosh'
+import { PlanType } from '../@types/PlanType'
 
 export default class SentencePlanApiClient {
   constructor(private readonly authClient: HmppsAuthClient) {}
@@ -68,5 +69,17 @@ export default class SentencePlanApiClient {
       path: `/goals/${parentGoalUuidId}/steps`,
       data: steps,
     })
+  }
+
+  async getPlanByUuid(planUuid: string) {
+    logger.info(`Getting plan with plan UUID: ${planUuid}`)
+    const token = await this.authClient.getSystemClientToken()
+    return SentencePlanApiClient.restClient(token).get<PlanType>({ path: `/plan/${planUuid}` })
+  }
+
+  async getPlanByOasysAssessmentPk(oasysAssessmentPk: string) {
+    logger.info(`Getting plan with OASys Assessment PK: ${oasysAssessmentPk}`)
+    const token = await this.authClient.getSystemClientToken()
+    return SentencePlanApiClient.restClient(token).get<PlanType>({ path: `/oasys/${oasysAssessmentPk}` })
   }
 }

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -8,6 +8,7 @@ import GoalService from './sentence-plan/goalService'
 import StepService from './sentence-plan/stepsService'
 import FormStorageService from './formStorageService'
 import HandoverContextService from './handover/handoverContextService'
+import PlanService from './sentence-plan/planService'
 
 export const services = () => {
   const { applicationInfo, sentencePlanApiClient, hmppsAuditClient } = dataAccess()
@@ -19,6 +20,7 @@ export const services = () => {
   const noteService = new NoteService(sentencePlanApiClient)
   const goalService = new GoalService(sentencePlanApiClient)
   const stepService = new StepService(sentencePlanApiClient)
+  const planService = new PlanService(sentencePlanApiClient)
 
   return {
     applicationInfo,
@@ -29,6 +31,7 @@ export const services = () => {
     noteService,
     goalService,
     stepService,
+    planService,
   }
 }
 

--- a/server/services/sentence-plan/planService.test.ts
+++ b/server/services/sentence-plan/planService.test.ts
@@ -1,0 +1,39 @@
+import { SentencePlanApiClient } from '../../data'
+import PlanService from './planService'
+import testPlan from '../../testutils/data/planData'
+
+jest.mock('../../data/sentencePlanApiClient')
+
+describe('PlanService', () => {
+  let sentencePlanApiClientMock: jest.Mocked<SentencePlanApiClient>
+  let planService: PlanService
+
+  beforeEach(() => {
+    sentencePlanApiClientMock = new SentencePlanApiClient(null) as jest.Mocked<SentencePlanApiClient>
+    planService = new PlanService(sentencePlanApiClientMock)
+  })
+
+  describe('getPlanByUuid', () => {
+    it('should call getPlanByUuid method of SentencePlanApiClient', async () => {
+      const mockPlan = testPlan
+
+      sentencePlanApiClientMock.getPlanByUuid.mockResolvedValue(mockPlan)
+
+      const result = await planService.getPlanByUuid('some-uuid')
+      expect(sentencePlanApiClientMock.getPlanByUuid).toHaveBeenCalledWith('some-uuid')
+      expect(result).toBe(mockPlan)
+    })
+  })
+
+  describe('getPlanByOasysAssessmentPk', () => {
+    it('should call getPlanByOasysAssessmentPk method of SentencePlanApiClient', async () => {
+      const mockPlan = testPlan
+
+      sentencePlanApiClientMock.getPlanByOasysAssessmentPk.mockResolvedValue(mockPlan)
+
+      const result = await planService.getPlanByOasysAssessmentPk('12345')
+      expect(sentencePlanApiClientMock.getPlanByOasysAssessmentPk).toHaveBeenCalledWith('12345')
+      expect(result).toBe(mockPlan)
+    })
+  })
+})

--- a/server/services/sentence-plan/planService.ts
+++ b/server/services/sentence-plan/planService.ts
@@ -1,0 +1,9 @@
+import SentencePlanApiClient from '../../data/sentencePlanApiClient'
+
+export default class PlanService {
+  constructor(private readonly sentencePlanApiClient: SentencePlanApiClient) {}
+
+  getPlanByUuid = this.sentencePlanApiClient.getPlanByUuid
+
+  getPlanByOasysAssessmentPk = this.sentencePlanApiClient.getPlanByOasysAssessmentPk
+}

--- a/server/testutils/data/planData.ts
+++ b/server/testutils/data/planData.ts
@@ -1,0 +1,10 @@
+import { PlanType } from '../../@types/PlanType'
+
+const testPlan: PlanType = {
+  uuid: '123-xyz-abc-456',
+  status: 'incomplete',
+  createdAt: new Date(Date.now() - 1000 * 60 * 60),
+  updatedAt: new Date(),
+}
+
+export default testPlan


### PR DESCRIPTION
- Added planService
- Added unit tests for planService
- Updated sentencePlanApiClient to have calls for both plans by their UUIDs, or find plans by OASys Assessment PKs
- Updated sentencePlanApiClient appropriately