### PR TITLE
SP2-441 - Add logic for getting plans when accessing the service

### DIFF
--- a/server/@types/Handover.ts
+++ b/server/@types/Handover.ts
@@ -3,6 +3,7 @@ export type HandoverContextData = {
   principal: HandoverPrincipal
   subject: HandoverSubject
   assessmentContext: HandoverAssessmentContext
+  sentencePlanContext: HandoverSentencePlanContext
 }
 
 export type HandoverPrincipal = {
@@ -29,9 +30,14 @@ export type HandoverAssessmentContext = {
   assessmentVersion: number
 }
 
+export type HandoverSentencePlanContext = {
+  oasysAssessmentPk: string
+  planVersion: number
+}
+
 export const enum Gender {
-  NotKnown = 'NOT_KNOWN',
-  Male = 'MALE',
-  Female = 'FEMALE',
-  NotSpecified = 'NOT_SPECIFIED',
+  NotKnown = 0,
+  Male = 1,
+  Female = 2,
+  NotSpecified = 9,
 }

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,5 +1,6 @@
-import type { UserDetails } from '../../services/userService'
 import { RequestServices } from '../../services'
+import { PlanType } from '../PlanType'
+import { HandoverContextData, HandoverPrincipal } from '../Handover'
 
 export default {}
 
@@ -8,13 +9,15 @@ declare module 'express-session' {
   interface SessionData {
     returnTo: string
     nowInMinutes: number
+    plan?: PlanType
     forms?: any
+    handover?: HandoverContextData
   }
 }
 
 export declare global {
   namespace Express {
-    interface User extends Partial<UserDetails> {
+    interface User extends Partial<HandoverPrincipal> {
       username: string
       token: string
       authSource: string

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -17,6 +17,7 @@ import InMemoryTokenStore from './tokenStore/inMemoryTokenStore'
 import config from '../config'
 import HmppsAuditClient from './hmppsAuditClient'
 import SentencePlanApiClient from './sentencePlanApiClient'
+import HandoverApiClient from './handoverApiClient'
 
 type RestClientBuilder<T> = (token: string) => T
 
@@ -25,16 +26,18 @@ export const dataAccess = () => {
     config.redis.enabled ? new RedisTokenStore(createRedisClient()) : new InMemoryTokenStore(),
   )
   const sentencePlanApiClient = new SentencePlanApiClient(hmppsAuthClient)
+  const handoverApiClient = new HandoverApiClient()
   const hmppsAuditClient = new HmppsAuditClient(config.sqs.audit)
 
   return {
     applicationInfo,
     hmppsAuthClient,
     sentencePlanApiClient,
+    handoverApiClient,
     hmppsAuditClient,
   }
 }
 
 export type DataAccess = ReturnType<typeof dataAccess>
 
-export { HmppsAuthClient, RestClientBuilder, SentencePlanApiClient, HmppsAuditClient }
+export { HmppsAuthClient, RestClientBuilder, SentencePlanApiClient, HandoverApiClient, HmppsAuditClient }

--- a/server/middleware/authorisationMiddleware.test.ts
+++ b/server/middleware/authorisationMiddleware.test.ts
@@ -1,73 +1,49 @@
-import jwt from 'jsonwebtoken'
-import type { Request, Response } from 'express'
-
+import { Request, Response, NextFunction } from 'express'
+import { Session } from 'express-session'
 import authorisationMiddleware from './authorisationMiddleware'
+import mockReq from '../testutils/preMadeMocks/mockReq'
+import mockRes from '../testutils/preMadeMocks/mockRes'
+import handoverData from '../testutils/data/handoverData'
 
-function createToken(authorities: string[]) {
-  const payload = {
-    user_name: 'USER1',
-    scope: ['read', 'write'],
-    auth_source: 'nomis',
-    authorities,
-    jti: 'a610a10-cca6-41db-985f-e87efb303aaf',
-    client_id: 'clientid',
-  }
-
-  return jwt.sign(payload, 'secret', { expiresIn: '1h' })
-}
+jest.mock('../services/sessionService', () => {
+  return jest.fn().mockImplementation(() => ({
+    getPrincipalDetails: jest.fn().mockReturnValue(handoverData.principal),
+  }))
+})
 
 describe('authorisationMiddleware', () => {
-  let req: Request
-  const next = jest.fn()
-
-  function createResWithToken({ authorities }: { authorities: string[] }): Response {
-    return {
-      locals: {
-        user: {
-          token: createToken(authorities),
-        },
-      },
-      redirect: jest.fn(),
-    } as unknown as Response
-  }
+  let req: Partial<Request>
+  let res: Partial<Response>
+  let next: NextFunction
 
   beforeEach(() => {
-    jest.resetAllMocks()
+    req = mockReq()
+    res = mockRes()
+    next = jest.fn()
   })
 
-  it('should return next when no required roles', () => {
-    const res = createResWithToken({ authorities: [] })
+  it('should call next if principal details are present', async () => {
+    ;(req.services.sessionService.getPrincipalDetails as jest.Mock).mockReturnValue({})
 
-    authorisationMiddleware()(req, res, next)
+    const middleware = authorisationMiddleware()
+    middleware(req as Request, res as Response, next)
 
+    expect(req.services!.sessionService.getPrincipalDetails).toHaveBeenCalled()
     expect(next).toHaveBeenCalled()
     expect(res.redirect).not.toHaveBeenCalled()
   })
 
-  it('should redirect when user has no authorised roles', () => {
-    const res = createResWithToken({ authorities: [] })
+  it('should redirect to /sign-in if principal details are not present', async () => {
+    ;(req.services.sessionService.getPrincipalDetails as jest.Mock).mockReturnValue(null)
+    req.originalUrl = '/test-url'
+    req.session = {} as Session
 
-    authorisationMiddleware(['SOME_REQUIRED_ROLE'])(req, res, next)
+    const middleware = authorisationMiddleware()
+    middleware(req as Request, res as Response, next)
 
+    expect(req.services!.sessionService.getPrincipalDetails).toHaveBeenCalled()
     expect(next).not.toHaveBeenCalled()
-    expect(res.redirect).toHaveBeenCalledWith('/authError')
-  })
-
-  it('should return next when user has authorised role', () => {
-    const res = createResWithToken({ authorities: ['ROLE_SOME_REQUIRED_ROLE'] })
-
-    authorisationMiddleware(['SOME_REQUIRED_ROLE'])(req, res, next)
-
-    expect(next).toHaveBeenCalled()
-    expect(res.redirect).not.toHaveBeenCalled()
-  })
-
-  it('should return next when user has authorised role and middleware created with ROLE_ prefix', () => {
-    const res = createResWithToken({ authorities: ['ROLE_SOME_REQUIRED_ROLE'] })
-
-    authorisationMiddleware(['ROLE_SOME_REQUIRED_ROLE'])(req, res, next)
-
-    expect(next).toHaveBeenCalled()
-    expect(res.redirect).not.toHaveBeenCalled()
+    expect(res.redirect).toHaveBeenCalledWith('/sign-in')
+    expect(req.session!.returnTo).toBe('/test-url')
   })
 })

--- a/server/middleware/authorisationMiddleware.ts
+++ b/server/middleware/authorisationMiddleware.ts
@@ -1,26 +1,12 @@
-import { jwtDecode } from 'jwt-decode'
 import type { RequestHandler } from 'express'
 
-import logger from '../../logger'
-import asyncMiddleware from './asyncMiddleware'
-
-export default function authorisationMiddleware(authorisedRoles: string[] = []): RequestHandler {
-  return asyncMiddleware((req, res, next) => {
-    // authorities in the user token will always be prefixed by ROLE_.
-    // Convert roles that are passed into this function without the prefix so that we match correctly.
-    const authorisedAuthorities = authorisedRoles.map(role => (role.startsWith('ROLE_') ? role : `ROLE_${role}`))
-    if (res.locals?.user?.token) {
-      const { authorities: roles = [] } = jwtDecode(res.locals.user.token) as { authorities?: string[] }
-
-      if (authorisedAuthorities.length && !roles.some(role => authorisedAuthorities.includes(role))) {
-        logger.error('User is not authorised to access this')
-        return res.redirect('/authError')
-      }
-
+export default function authorisationMiddleware(): RequestHandler {
+  return (req, res, next) => {
+    if (req.services.sessionService.getPrincipalDetails()) {
       return next()
     }
 
     req.session.returnTo = req.originalUrl
     return res.redirect('/sign-in')
-  })
+  }
 }

--- a/server/routes/aboutPop/AboutPopController.test.ts
+++ b/server/routes/aboutPop/AboutPopController.test.ts
@@ -26,9 +26,9 @@ jest.mock('../../services/sentence-plan/infoService', () => {
     getRoSHData: jest.fn().mockResolvedValue(parsedRoshData),
   }))
 })
-jest.mock('../../services/handover/handoverContextService', () => {
+jest.mock('../../services/sessionService', () => {
   return jest.fn().mockImplementation(() => ({
-    getContext: jest.fn().mockResolvedValue(handoverData),
+    getSubjectDetails: jest.fn().mockReturnValue(handoverData.subject),
   }))
 })
 

--- a/server/routes/aboutPop/AboutPopController.ts
+++ b/server/routes/aboutPop/AboutPopController.ts
@@ -3,7 +3,6 @@ import locale from './locale.json'
 import InfoService from '../../services/sentence-plan/infoService'
 import ReferentialDataService from '../../services/sentence-plan/referentialDataService'
 import { toKebabCase } from '../../utils/utils'
-import { HandoverContextData } from '../../@types/Handover'
 
 export default class AboutPopController {
   constructor(
@@ -15,20 +14,9 @@ export default class AboutPopController {
     const { errors } = req
 
     try {
-      const contextData: HandoverContextData = await req.services.handoverContextService.getContext()
-      const { crn, dateOfBirth } = contextData.subject
-      const popData = {
-        ...contextData.subject,
-        dateOfBirth: new Date(dateOfBirth).toLocaleDateString('en-GB', {
-          day: 'numeric',
-          month: 'long',
-          year: 'numeric',
-        }),
-      }
+      const popData = req.services.sessionService.getSubjectDetails()
       const referenceData = await this.buildReferenceData()
-      // comented out till we are clear which data we will receive from this service
-      // const popData = await this.infoService.getPopData(crn)
-      const roshData = await this.infoService.getRoSHData(crn)
+      const roshData = await this.infoService.getRoSHData(popData.crn)
       return res.render('pages/about-pop', {
         locale: locale.en,
         data: {

--- a/server/routes/aboutPop/routes.test.ts
+++ b/server/routes/aboutPop/routes.test.ts
@@ -27,11 +27,12 @@ jest.mock('../../services/sentence-plan/infoService', () => {
     getRoSHData: jest.fn().mockResolvedValue(roSHData),
   }))
 })
-jest.mock('../../services/handover/handoverContextService', () => {
+jest.mock('../../services/sessionService', () => {
   return jest.fn().mockImplementation(() => ({
-    getContext: jest.fn().mockResolvedValue(handoverData),
+    getSubjectDetails: jest.fn().mockReturnValue(handoverData.subject),
   }))
 })
+
 let app: Express
 const referentialDataService = new ReferentialDataService(null) as jest.Mocked<ReferentialDataService>
 const infoService = new InfoService(null) as jest.Mocked<InfoService>

--- a/server/services/handover/handoverContextService.test.ts
+++ b/server/services/handover/handoverContextService.test.ts
@@ -1,0 +1,41 @@
+import HandoverApiClient from '../../data/handoverApiClient'
+import HandoverContextService from './handoverContextService'
+import testHandoverContext from '../../testutils/data/handoverData'
+
+jest.mock('../../data/handoverApiClient')
+
+describe('HandoverContextService', () => {
+  let handoverApiClient: jest.Mocked<HandoverApiClient>
+  let handoverContextService: HandoverContextService
+
+  beforeEach(() => {
+    handoverApiClient = new HandoverApiClient() as jest.Mocked<HandoverApiClient>
+    handoverContextService = new HandoverContextService(handoverApiClient)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('getContext', () => {
+    it('should return context data when getContext is called', async () => {
+      const mockHandoverToken = 'mock-token'
+
+      handoverApiClient.getContextData.mockResolvedValue(testHandoverContext)
+
+      const result = await handoverContextService.getContext(mockHandoverToken)
+
+      expect(handoverApiClient.getContextData).toHaveBeenCalledWith(mockHandoverToken)
+      expect(result).toEqual(testHandoverContext)
+    })
+
+    it('should throw an error if getContextData fails', async () => {
+      const mockHandoverToken = 'mock-token'
+      const mockError = new Error('Failed to fetch context data')
+
+      handoverApiClient.getContextData.mockRejectedValue(mockError)
+
+      await expect(handoverContextService.getContext(mockHandoverToken)).rejects.toThrow('Failed to fetch context data')
+    })
+  })
+})

--- a/server/services/handover/handoverContextService.ts
+++ b/server/services/handover/handoverContextService.ts
@@ -1,16 +1,10 @@
-import { Request } from 'express'
 import HandoverApiClient from '../../data/handoverApiClient'
 import { HandoverContextData } from '../../@types/Handover'
 
 export default class HandoverContextService {
-  constructor(
-    private readonly req: Request,
-    private readonly handoverApiClient = new HandoverApiClient(),
-  ) {}
+  constructor(private readonly handoverApiClient = new HandoverApiClient()) {}
 
-  getToken = () => this.req.res.locals?.user?.token
-
-  async getContext(): Promise<HandoverContextData> {
-    return this.handoverApiClient.getContextData(this.getToken())
+  async getContext(handoverToken: string): Promise<HandoverContextData> {
+    return this.handoverApiClient.getContextData(handoverToken)
   }
 }

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -10,6 +10,7 @@ import StepService from './sentence-plan/stepsService'
 import FormStorageService from './formStorageService'
 import HandoverContextService from './handover/handoverContextService'
 import PlanService from './sentence-plan/planService'
+import SessionService from './sessionService'
 
 export const services = () => {
   const { applicationInfo, sentencePlanApiClient, handoverApiClient, hmppsAuditClient } = dataAccess()
@@ -38,10 +39,10 @@ export const services = () => {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const requestServices = (appServices: Services) => ({
   formStorageService: (req: Request) => new FormStorageService(req),
-  handoverContextService: (req: Request) => new HandoverContextService(req),
+  sessionService: (req: Request) =>
+    new SessionService(req, appServices.handoverContextService, appServices.planService),
 })
 
 export type RequestServices = {

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -12,7 +12,7 @@ import HandoverContextService from './handover/handoverContextService'
 import PlanService from './sentence-plan/planService'
 
 export const services = () => {
-  const { applicationInfo, sentencePlanApiClient, hmppsAuditClient } = dataAccess()
+  const { applicationInfo, sentencePlanApiClient, handoverApiClient, hmppsAuditClient } = dataAccess()
 
   const auditService = new AuditService(hmppsAuditClient)
   const helloWorldService = new HelloWorldService(sentencePlanApiClient)
@@ -22,12 +22,14 @@ export const services = () => {
   const goalService = new GoalService(sentencePlanApiClient)
   const stepService = new StepService(sentencePlanApiClient)
   const planService = new PlanService(sentencePlanApiClient)
+  const handoverContextService = new HandoverContextService(handoverApiClient)
 
   return {
     applicationInfo,
     auditService,
     helloWorldService,
     referentialDataService,
+    handoverContextService,
     infoService,
     noteService,
     goalService,

--- a/server/services/sentence-plan/planService.ts
+++ b/server/services/sentence-plan/planService.ts
@@ -3,7 +3,8 @@ import SentencePlanApiClient from '../../data/sentencePlanApiClient'
 export default class PlanService {
   constructor(private readonly sentencePlanApiClient: SentencePlanApiClient) {}
 
-  getPlanByUuid = this.sentencePlanApiClient.getPlanByUuid
+  getPlanByUuid = (uuid: string) => this.sentencePlanApiClient.getPlanByUuid(uuid)
 
-  getPlanByOasysAssessmentPk = this.sentencePlanApiClient.getPlanByOasysAssessmentPk
+  getPlanByOasysAssessmentPk = (oasysAssessmentPk: string) =>
+    this.sentencePlanApiClient.getPlanByOasysAssessmentPk(oasysAssessmentPk)
 }

--- a/server/services/sessionService.test.ts
+++ b/server/services/sessionService.test.ts
@@ -1,0 +1,92 @@
+import testPlan from '../testutils/data/planData'
+import mockReq from '../testutils/preMadeMocks/mockReq'
+import SessionService from './sessionService'
+import testHandoverContext from '../testutils/data/handoverData'
+import PlanService from './sentence-plan/planService'
+import HandoverContextService from './handover/handoverContextService'
+
+jest.mock('./sentence-plan/planService', () => {
+  return jest.fn().mockImplementation(() => ({
+    getPlanByOasysAssessmentPk: jest.fn(),
+  }))
+})
+jest.mock('./handover/handoverContextService', () => {
+  return jest.fn().mockImplementation(() => ({
+    getContext: jest.fn(),
+  }))
+})
+
+describe('SessionService', () => {
+  let requestMock: any
+  let handoverContextServiceMock: jest.Mocked<HandoverContextService>
+  let planServiceMock: jest.Mocked<PlanService>
+  let sessionService: SessionService
+
+  beforeEach(() => {
+    requestMock = mockReq()
+    handoverContextServiceMock = new HandoverContextService(null) as jest.Mocked<HandoverContextService>
+    planServiceMock = new PlanService(null) as jest.Mocked<PlanService>
+    sessionService = new SessionService(requestMock, handoverContextServiceMock, planServiceMock)
+  })
+
+  describe('setupSession', () => {
+    it('should set up session with handover and plan', async () => {
+      handoverContextServiceMock.getContext.mockResolvedValue(testHandoverContext)
+      planServiceMock.getPlanByOasysAssessmentPk.mockResolvedValue(testPlan)
+
+      await sessionService.setupSession()
+
+      expect(requestMock.session.handover).toEqual(testHandoverContext)
+      expect(requestMock.session.plan).toEqual(testPlan)
+    })
+
+    it('should throw if either getContext or getPlanByOasysAssessmentPk fails', async () => {
+      handoverContextServiceMock.getContext.mockRejectedValue('getContext')
+      planServiceMock.getPlanByOasysAssessmentPk.mockRejectedValue('getPlanByOasysAssessmentPk')
+
+      await expect(sessionService.setupSession()).rejects.toThrow('getContext')
+
+      handoverContextServiceMock.getContext.mockResolvedValue(testHandoverContext)
+
+      await expect(sessionService.setupSession()).rejects.toThrow('getPlanByOasysAssessmentPk')
+    })
+  })
+
+  describe('getOasysAssessmentPk', () => {
+    it('should get OASys assessment PK from session', async () => {
+      requestMock.session = {
+        handover: testHandoverContext,
+      }
+
+      expect(sessionService.getOasysAssessmentPk()).toBe(testHandoverContext.sentencePlanContext.oasysAssessmentPk)
+    })
+  })
+
+  describe('getPlanUUID', () => {
+    it('should get plan UUID from session', async () => {
+      requestMock.session = {
+        plan: testPlan,
+      }
+
+      expect(sessionService.getPlanUUID()).toBe(testPlan.uuid)
+    })
+  })
+
+  describe('getPrincipalDetails', () => {
+    it('should get principal details from session', async () => {
+      requestMock.session = {
+        handover: testHandoverContext,
+      }
+      expect(sessionService.getPrincipalDetails()).toBe(testHandoverContext.principal)
+    })
+  })
+
+  describe('getSubjectDetails', () => {
+    it('should get subject details from session', async () => {
+      requestMock.session = {
+        handover: testHandoverContext,
+      }
+      expect(sessionService.getSubjectDetails()).toBe(testHandoverContext.subject)
+    })
+  })
+})

--- a/server/services/sessionService.ts
+++ b/server/services/sessionService.ts
@@ -1,0 +1,31 @@
+import HandoverContextService from './handover/handoverContextService'
+import PlanService from './sentence-plan/planService'
+import Logger from '../../logger'
+
+export default class SessionService {
+  constructor(
+    private readonly request: Express.Request,
+    private readonly handoverContextService: HandoverContextService,
+    private readonly planService: PlanService,
+  ) {}
+
+  setupSession = async () => {
+    try {
+      this.request.session.handover = await this.handoverContextService.getContext(this.getToken())
+      this.request.session.plan = await this.planService.getPlanByOasysAssessmentPk(this.getOasysAssessmentPk())
+    } catch (e) {
+      Logger.error('Failed to setup session:', e)
+      throw Error(e)
+    }
+  }
+
+  private getToken = () => this.request.user?.token
+
+  getOasysAssessmentPk = () => this.request.session.handover?.sentencePlanContext?.oasysAssessmentPk
+
+  getPlanUUID = () => this.request.session.plan?.uuid
+
+  getPrincipalDetails = () => this.request.session.handover?.principal
+
+  getSubjectDetails = () => this.request.session.handover?.subject
+}

--- a/server/testutils/data/handoverData.ts
+++ b/server/testutils/data/handoverData.ts
@@ -1,6 +1,7 @@
-export default {
+import { HandoverContextData } from '../../@types/Handover'
+
+const testHandoverContext: HandoverContextData = {
   handoverSessionId: 'e7501b21-3951-426d-9a73-0c2c4527aa27',
-  createdAt: '2024-06-12T15:03:19.387906919',
   principal: {
     identifier: 'a23ccacf-7160-4431-9b4d-c560be9c9f5c',
     displayName: 'Dr. Benjamin Runolfsdottir',
@@ -19,5 +20,7 @@ export default {
     sexuallyMotivatedOffenceHistory: 'YES',
   },
   assessmentContext: { oasysAssessmentPk: '306708', assessmentVersion: 0 },
-  sentencePlanContext: null,
+  sentencePlanContext: { oasysAssessmentPk: '306708', planVersion: 0 },
 }
+
+export default testHandoverContext

--- a/server/testutils/data/popData.ts
+++ b/server/testutils/data/popData.ts
@@ -4,7 +4,7 @@ const testPopData = {
   nomisId: '',
   givenName: 'Buster',
   familyName: 'Sanford',
-  dateOfBirth: '15 January 2002',
+  dateOfBirth: '2002-01-15',
   gender: 1,
   location: 'COMMUNITY',
   sexuallyMotivatedOffenceHistory: 'YES',

--- a/server/testutils/preMadeMocks/mockReq.ts
+++ b/server/testutils/preMadeMocks/mockReq.ts
@@ -1,10 +1,8 @@
 import { Request } from 'express'
 import FormStorageService from '../../services/formStorageService'
-import HandoverContextService from '../../services/handover/handoverContextService'
+import SessionService from '../../services/sessionService'
 
 jest.mock('../../services/formStorageService')
-
-jest.mock('../../services/handover/handoverContextService')
 
 type MockReqOptions = {
   body?: Record<string, any>

--- a/server/testutils/preMadeMocks/mockReq.ts
+++ b/server/testutils/preMadeMocks/mockReq.ts
@@ -8,6 +8,7 @@ type MockReqOptions = {
   body?: Record<string, any>
   params?: Record<string, any>
   query?: Record<string, any>
+  session?: Record<string, any>
   errors?: {
     body?: Record<string, any>
     params?: Record<string, any>
@@ -21,9 +22,10 @@ const mockReq = ({
   params = {},
   query = {},
   errors = {},
+  session = {},
   services = {
     formStorageService: new FormStorageService(null),
-    handoverContextService: new HandoverContextService(null),
+    sessionService: new SessionService(null, null, null),
   },
 }: MockReqOptions = {}): jest.Mocked<Request> =>
   ({
@@ -31,6 +33,7 @@ const mockReq = ({
     params,
     query,
     errors,
+    session,
     services,
   }) as jest.Mocked<Request>
 


### PR DESCRIPTION
- Refactor HandoverContextService to remove it from request scope
- Add SessionService that handles
  - Handover context data
  - Current plan data 
- Updated authentication/authorization logic to setup session with handover information and plan data
- Updated tests