### PR TITLE
Small changes to docker/make to make cleanup better

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Before starting, run `make install-node-modules`.
 
 **Note:** Due to requiring authentication through the ARNS Handover Service,
 to access the Sentence Plan UI - you can create a handover through the OAStub 
-hosted at http://localhost:7072 and select `localhost` as the target service.
+hosted at http://localhost:7072 and select `Sentence Plan` as the target service.
 
 ### Production
 1. To start a production version of the application, run `make up`

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       INGRESS_URL: http://localhost:3000
       PRODUCT_ID: ARNS
       AUDIT_ENABLED: "false"
-      REDIS_ENABLED: true
+      REDIS_ENABLED: false
       REDIS_HOST: redis
       SYSTEM_CLIENT_ID: sentence-plan-api-client
       SYSTEM_CLIENT_SECRET: sentence-plan-api-client
@@ -77,6 +77,8 @@ services:
       HMPPS_AUTH_URL: http://hmpps-auth:9090/auth
       HMPPS_ARNS_HANDOVER_URL: http://arns-handover:7070
       SBNA_API_URL: false
+      SP_API_URL: http://api:8080
+
 
   api:
     image: quay.io/hmpps/hmpps-sentence-plan:latest

--- a/makefile
+++ b/makefile
@@ -62,8 +62,9 @@ install-node-modules: ## Installs Node modules into the Docker volume.
 
 clean: ## Stops and removes all project containers. Deletes local build/cache directories.
 	docker compose down
-	docker volume rm ${PROJECT_NAME}_node_modules
+	docker volume ls -qf "dangling=true" | xargs -r docker volume rm
 	rm -rf dist node_modules test_results
 
 update: ## Downloads the latest versions of container images.
 	docker compose ${LOCAL_COMPOSE_FILES} pull
+	npm i


### PR DESCRIPTION
- Updated `make clean` 
  - Removes dangling volumes now, so will cleanup redis/postgres volumes
- Updated `make update` 
  - Calls `npm i` now
- Disabled redis for OAStub as it's not needed
- Added SP_API_URL for OAStub 