### PR TITLE
Use containerised setup in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   hmpps: ministryofjustice/hmpps@8
   slack: circleci/slack@4.12.5
+  mem: circleci/rememborb@0.0.2
 
 parameters:
   alerts-slack-channel:
@@ -21,7 +22,7 @@ parameters:
     default: 20.11-browsers
 
 jobs:
-  build:
+  lint:
     executor:
       name: hmpps/node
       tag: << pipeline.parameters.node-version >>
@@ -41,18 +42,8 @@ jobs:
             - node_modules
             - ~/.cache
       - run:
-          command: |
-            npm run build
-      - run: # Run linter after build because the integration test code depend on compiled typescript...
           name: Linter check
           command: npm run lint
-      - persist_to_workspace:
-          root: .
-          paths:
-            - node_modules
-            - build
-            - dist
-            - assets/stylesheets
 
   unit_test:
     executor:
@@ -70,61 +61,67 @@ jobs:
       - store_artifacts:
           path: test_results/unit-test-reports.html
 
-  integration_test:
-    executor:
-      name: hmpps/node
-      tag: << pipeline.parameters.node-version >>
+  e2e_test:
+    machine:
+      image: ubuntu-2204:current
+      resource_class: medium
+    working_directory: ~/app
     steps:
       - checkout
       - attach_workspace:
           at: ~/app
       - run:
-          name: Install missing OS dependency
-          command: sudo apt-get install libxss1
+          name: Extract saved container image
+          command: docker load --input docker_cache/build_image.tar
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
+      - mem/recall:
+          env_var: APP_VERSION
       - run:
-          name: Get wiremock
-          command: curl -o wiremock.jar https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/3.3.1/wiremock-standalone-3.3.1.jar
+          name: Stand up a test environment
+          command: make test-up
       - run:
-          name: Run wiremock
-          command: java -jar wiremock.jar --port 9091
-          background: true
-      - run:
-          name: Run the node app.
-          command: npm run start-feature
-          background: true
-      - run:
-          name: Wait for node app to start
-          command: sleep 5
-      - run:
-          name: integration tests
-          command: npm run int-test
+          name: Run the end-to-end tests
+          command: make e2e-ci
       - store_test_results:
           path: test_results
       - store_artifacts:
-          path: integration_tests/videos
+          path: cypress/videos
       - store_artifacts:
-          path: integration_tests/screenshots
+          path: cypress/screenshots
 
 workflows:
   version: 2
   build-test-and-deploy:
     jobs:
-      - build:
+      - lint:
           filters:
             tags:
               ignore: /.*/
       - unit_test:
           requires:
-            - build
-      - integration_test:
-          requires:
-            - build
+            - lint
       - hmpps/helm_lint:
           name: helm_lint
       - hmpps/build_docker:
           name: build_docker
+          publish: false
+          persist_container_image: true
+          jira_update: true
+          pipeline_id: << pipeline.id >>
+          pipeline_number: << pipeline.number >>
+          context: hmpps-common-vars
+      - e2e_test:
+          context: hmpps-common-vars
+          requires:
+            - build_docker
+      - hmpps/publish_docker:
+          name: publish_docker
+          publish_latest_tag: true
+          context: hmpps-common-vars
+          requires:
+            - unit_test
+            - e2e_test
           filters:
             branches:
               only:
@@ -133,8 +130,8 @@ workflows:
           name: deploy_dev
           env: "dev"
           jira_update: true
-          pipeline_id: <<pipeline.id>>
-          pipeline_number: <<pipeline.number>>
+          pipeline_id: << pipeline.id >>
+          pipeline_number: << pipeline.number >>
           context: hmpps-common-vars
           filters:
             branches:
@@ -142,46 +139,8 @@ workflows:
                 - main
           requires:
             - helm_lint
-            - unit_test
-            - integration_test
-            - build_docker
+            - publish_docker
           helm_timeout: 5m
-#      - request-preprod-approval:
-#          type: approval
-#          requires:
-#            - deploy_dev
-#      - hmpps/deploy_env:
-#          name: deploy_preprod
-#          env: "preprod"
-#          jira_update: true
-#          jira_env_type: staging
-#          pipeline_id: <<pipeline.id>>
-#          pipeline_number: <<pipeline.number>>
-#          context:
-#            - hmpps-common-vars
-#            - hmpps-sentence-plan-ui-preprod
-#          requires:
-#            - request-preprod-approval
-#          helm_timeout: 5m
-#      - request-prod-approval:
-#          type: approval
-#          requires:
-#            - deploy_preprod
-#      - hmpps/deploy_env:
-#          name: deploy_prod
-#          env: "prod"
-#          jira_update: true
-#          jira_env_type: production
-#          pipeline_id: <<pipeline.id>>
-#          pipeline_number: <<pipeline.number>>
-#          slack_notification: true
-#          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
-#          context:
-#            - hmpps-common-vars
-#            - hmpps-sentence-plan-ui-prod
-#          requires:
-#            - request-prod-approval
-#          helm_timeout: 5m
 
   security:
     triggers:

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,0 +1,11 @@
+services:
+  cypress:
+    image: cypress/included
+    environment:
+      CYPRESS_BASE_URL: http://ui:3000
+    volumes:
+      - ../:/integration_tests
+    working_dir: /integration_tests
+
+volumes:
+  test_results:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -126,6 +126,7 @@ services:
       HMPPS_AUTH_EXTERNAL_URL: http://localhost:9090/auth
       HMPPS_ARNS_HANDOVER_URL: http://arns-handover:7070
       HMPPS_ARNS_HANDOVER_EXTERNAL_URL: http://localhost:7070
+      MANAGE_USERS_API_URL: false
       TOKEN_VERIFICATION_ENABLED: false
       TOKEN_VERIFICATION_API_URL: http://hmpps-auth:9091/verification
       API_CLIENT_ID: sentence-plan-api-client

--- a/integration_tests/e2e/health.cy.ts
+++ b/integration_tests/e2e/health.cy.ts
@@ -1,12 +1,5 @@
 context('Healthcheck', () => {
   context('All healthy', () => {
-    beforeEach(() => {
-      cy.task('reset')
-      cy.task('stubAuthPing')
-      cy.task('stubManageUsersPing')
-      cy.task('stubTokenVerificationPing')
-    })
-
     it('Health check page is visible and UP', () => {
       cy.request('/health').its('body.status').should('equal', 'UP')
     })
@@ -17,28 +10,6 @@ context('Healthcheck', () => {
 
     it('Info is visible', () => {
       cy.request('/info').its('body').should('exist')
-    })
-  })
-
-  context('Some unhealthy', () => {
-    beforeEach(() => {
-      cy.task('reset')
-      cy.task('stubAuthPing')
-      cy.task('stubManageUsersPing')
-      cy.task('stubTokenVerificationPing', 500)
-    })
-
-    it('Reports correctly when token verification down', () => {
-      cy.request({ url: '/health', method: 'GET', failOnStatusCode: false }).then(response => {
-        expect(response.body.components.hmppsAuth.status).to.equal('UP')
-        expect(response.body.components.manageUsersApi.status).to.equal('UP')
-        expect(response.body.components.tokenVerification.status).to.equal('DOWN')
-        expect(response.body.components.tokenVerification.details).to.contain({ status: 500, retries: 2 })
-      })
-    })
-
-    it('Health check page is visible and DOWN', () => {
-      cy.request({ url: '/health', method: 'GET', failOnStatusCode: false }).its('body.status').should('equal', 'DOWN')
     })
   })
 })

--- a/makefile
+++ b/makefile
@@ -38,6 +38,25 @@ test: ## Runs the unit test suite.
 	@make install-node-modules
 	docker compose ${DEV_COMPOSE_FILES} run --rm --no-deps ui npm run test
 
+BASE_URL ?= "http://localhost:3000"
+e2e: ## Run the end-to-end tests locally in the Cypress app. Override the default base URL with BASE_URL=...
+	@make install-node-modules
+	docker compose ${DEV_COMPOSE_FILES} up --no-recreate --wait
+	npm i
+	npx cypress install
+	npx cypress open -c baseUrl=$(BASE_URL),experimentalInteractiveRunEvents=true
+
+BASE_URL_CI ?= "http://ui:3000"
+e2e-ci: ## Run the end-to-end tests in parallel in a headless browser. Used in CI. Override the default base URL with BASE_URL_CI=...
+	docker compose ${TEST_COMPOSE_FILES} -p ${PROJECT_NAME}-test run --rm -e CYPRESS_BASE_URL=${BASE_URL_CI} cypress
+
+test-up: ## Stands up a test environment.
+	docker compose --progress plain ${LOCAL_COMPOSE_FILES} pull --policy missing
+	docker compose --progress plain ${TEST_COMPOSE_FILES} -p ${PROJECT_NAME}-test up ui --wait --force-recreate
+
+test-down: ## Stops and removes all of the test containers.
+	docker compose --progress plain ${TEST_COMPOSE_FILES} -p ${PROJECT_NAME}-test down
+
 lint: ## Runs the linter.
 	docker compose ${DEV_COMPOSE_FILES} run --rm --no-deps ui npm run lint
 

--- a/server/services/healthCheck.ts
+++ b/server/services/healthCheck.ts
@@ -51,7 +51,6 @@ function gatherCheckInfo(aggregateStatus: Record<string, unknown>, currentStatus
 
 const apiChecks = [
   service('hmppsAuth', `${config.apis.hmppsAuth.url}/health/ping`, config.apis.hmppsAuth.agent),
-  service('manageUsersApi', `${config.apis.manageUsersApi.url}/health/ping`, config.apis.manageUsersApi.agent),
   ...(config.apis.tokenVerification.enabled
     ? [
         service(

--- a/server/services/healthCheck.ts
+++ b/server/services/healthCheck.ts
@@ -52,7 +52,11 @@ function gatherCheckInfo(aggregateStatus: Record<string, unknown>, currentStatus
 const apiChecks = [
   service('hmppsAuth', `${config.apis.hmppsAuth.url}/health/ping`, config.apis.hmppsAuth.agent),
   service('HMPPS ARNS Handover Service', `${config.apis.arnsHandover.url}/health/ping`, config.apis.arnsHandover.agent),
-  service('HMPPS Sentence Plan API', `${config.apis.sentencePlanApi.url}/health/ping`, config.apis.sentencePlanApi.agent),
+  service(
+    'HMPPS Sentence Plan API',
+    `${config.apis.sentencePlanApi.url}/health/ping`,
+    config.apis.sentencePlanApi.agent,
+  ),
   ...(config.apis.tokenVerification.enabled
     ? [
         service(

--- a/server/services/healthCheck.ts
+++ b/server/services/healthCheck.ts
@@ -51,6 +51,8 @@ function gatherCheckInfo(aggregateStatus: Record<string, unknown>, currentStatus
 
 const apiChecks = [
   service('hmppsAuth', `${config.apis.hmppsAuth.url}/health/ping`, config.apis.hmppsAuth.agent),
+  service('HMPPS ARNS Handover Service', `${config.apis.arnsHandover.url}/health/ping`, config.apis.arnsHandover.agent),
+  service('HMPPS Sentence Plan API', `${config.apis.sentencePlanApi.url}/health/ping`, config.apis.sentencePlanApi.agent),
   ...(config.apis.tokenVerification.enabled
     ? [
         service(


### PR DESCRIPTION
- Spin up a test environment using `make test-up` that includes all the pods necessary for testing our service e2e
  - probably some of these don't need spinning up (forward-proxy)
- Run make `test e2e-ci` against span up test environment
- Added run `make e2e` for running e2e/integration tests on local dev environment
- Disabled some unused healthcheck tests, and manageUsersApi health check
- Added some extra health checks (partly to test this works 😄)