### PR TITLE
Changed IDs to fix autocomplete

### DIFF
--- a/assets/js/autocomplete/goal-autocomplete.js
+++ b/assets/js/autocomplete/goal-autocomplete.js
@@ -1,33 +1,33 @@
-import accessibleAutocomplete from "accessible-autocomplete";
+import accessibleAutocomplete from 'accessible-autocomplete'
 
-const GOAL_AUTOCOMPLETE_WRAPPER_CLASS = "goal-input-autocomplete-wrapper"
-const GOAL_AUTOCOMPLETE_INPUT_ID = "goal-input-autocomplete"
+const GOAL_AUTOCOMPLETE_WRAPPER_CLASS = 'goal-input-autocomplete-wrapper'
+const GOAL_INPUT_ID = 'goal-input'
 const AREA_OF_NEED_INPUT_ID = '_areaOfNeed'
 
 document.addEventListener('DOMContentLoaded', () => {
-    if (document.querySelector(`.${GOAL_AUTOCOMPLETE_WRAPPER_CLASS}`)) initializeGoalInputAutocomplete()
+  if (document.querySelector(`.${GOAL_AUTOCOMPLETE_WRAPPER_CLASS}`)) initializeGoalInputAutocomplete()
 })
 
 async function getGoalOptionsByAreaOfNeed(areaOfNeed) {
-    const response = await fetch(`/reference-data/areaOfNeed/${areaOfNeed}/goals`)
-    const { goals } = await response.json()
-    return goals
+  const response = await fetch(`/reference-data/areaOfNeed/${areaOfNeed}/goals`)
+  const { goals } = await response.json()
+  return goals
 }
 
 async function initializeGoalInputAutocomplete() {
-    const areaOfNeed = document.querySelector(`#${AREA_OF_NEED_INPUT_ID}`)?.value
-    const source = await getGoalOptionsByAreaOfNeed(areaOfNeed);
-    const wrapperElement = document.querySelector(`.${GOAL_AUTOCOMPLETE_WRAPPER_CLASS}`)
-    const inputElement = document.querySelector(`#${GOAL_AUTOCOMPLETE_INPUT_ID}`)
-    const defaultValue = inputElement?.value ?? ''
-    inputElement.remove()
+  const areaOfNeed = document.querySelector(`#${AREA_OF_NEED_INPUT_ID}`)?.value
+  const source = await getGoalOptionsByAreaOfNeed(areaOfNeed)
+  const wrapperElement = document.querySelector(`.${GOAL_AUTOCOMPLETE_WRAPPER_CLASS}`)
+  const inputElement = document.querySelector(`#${GOAL_INPUT_ID}`)
+  const defaultValue = inputElement?.value ?? ''
+  inputElement.remove()
 
-    accessibleAutocomplete({
-        element: wrapperElement,
-        id: GOAL_AUTOCOMPLETE_INPUT_ID,
-        name: "goal-input-autocomplete",
-        source,
-        minLength: 3,
-        defaultValue
-    })
+  accessibleAutocomplete({
+    element: wrapperElement,
+    id: `${GOAL_INPUT_ID}-autocomplete`,
+    name: `${GOAL_INPUT_ID}-autocomplete`,
+    source,
+    minLength: 3,
+    defaultValue,
+  })
 }

--- a/server/views/pages/create-goal.njk
+++ b/server/views/pages/create-goal.njk
@@ -159,7 +159,7 @@
                         classes: "goal-input-autocomplete-wrapper"
                     },
                     errorMessage: getFormattedError(errors, locale, 'goal-input-autocomplete'),
-                    id: "goal-input-autocomplete",
+                    id: "goal-input",
                     name: "goal-input-autocomplete",
                     value: data.form['goal-input-autocomplete']
                 }) }}

--- a/server/views/pages/edit-goal.njk
+++ b/server/views/pages/edit-goal.njk
@@ -142,7 +142,7 @@
                         classes: "goal-input-autocomplete-wrapper"
                     },
                     errorMessage: getFormattedError(errors, locale, 'goal-input-autocomplete'),
-                    id: "goal-input-autocomplete",
+                    id: "goal-input",
                     name: "goal-input-autocomplete",
                     value: data.form['goal-input-autocomplete']
                 }) }}


### PR DESCRIPTION
- The static, an autocomplete field, both used the same ID
- It seems like, when the page load,  Cypress would begin running tests and targeting the field with id `goal-input-autocomplete`. 
- This was problematic because the field would be deleted from the DOM and replaced with the autocomplete version of the field, but Cypress would still attempt to type in the old, removed field - causing the test failure.