### PR TITLE
Add support for nested validations

### DIFF
--- a/server/middleware/validationMiddleware.test.ts
+++ b/server/middleware/validationMiddleware.test.ts
@@ -1,75 +1,180 @@
 /* eslint-disable max-classes-per-file */
-import { IsInt, IsNotEmpty, Min, MinLength } from 'class-validator'
-import validate from './validationMiddleware'
+import { IsInt, IsNotEmpty, Min, MinLength, ValidateNested } from 'class-validator'
+import { Expose, plainToInstance, Transform } from 'class-transformer'
+import validate, { getValidationErrors } from './validationMiddleware'
 import mockReq from '../testutils/preMadeMocks/mockReq'
 import mockRes from '../testutils/preMadeMocks/mockRes'
 
-describe('Validation Middleware', () => {
-  class BodyDTO {
-    @IsNotEmpty()
-    name: string
-  }
+describe('validation', () => {
+  describe('getValidationErrors', () => {
+    describe('nested validation', () => {
+      class TestNestedModel {
+        @IsNotEmpty()
+        foo: string
 
-  class ParamsDTO {
-    @IsInt()
-    @Min(3)
-    id: number
-  }
+        @IsNotEmpty()
+        bar: string
+      }
 
-  class QueryDTO {
-    @MinLength(9)
-    search: string
-  }
+      class TestModel {
+        @IsNotEmpty()
+        title: string
 
-  it('should attach errors to req and call next', () => {
-    const req = mockReq({
-      body: { name: '' },
-      params: { id: 'abc' },
-      query: { search: 'tooShort' },
+        @Expose()
+        @ValidateNested()
+        @Transform(({ obj }) => {
+          return Object.keys(obj)
+            .filter(key => key.startsWith('nested-foo-'))
+            .map(key => key.slice(-1))
+            .map(row =>
+              plainToInstance(TestNestedModel, {
+                foo: obj[`nested-foo-${row}`],
+                bar: obj[`nested-bar-${row}`],
+              }),
+            )
+        })
+        nested: TestNestedModel[]
+      }
+
+      it('should return no errors when nested validation passes', () => {
+        const test = {
+          title: 'a test title',
+          'nested-foo-1': 'Foo 1',
+          'nested-bar-1': 'Bar 1',
+          'nested-foo-2': 'Foo 2',
+          'nested-bar-2': 'bar 2',
+        }
+
+        const errors = getValidationErrors(test, TestModel)
+        expect(errors).toEqual({})
+      })
+
+      it('should return errors when nested validation fails', () => {
+        const test = {
+          title: 'a test title',
+          'nested-foo-1': 'Foo 1',
+          'nested-foo-2': 'Foo 2',
+          'nested-bar-2': 'bar 2',
+        }
+
+        const errors = getValidationErrors(test, TestModel)
+        expect(errors).toEqual({
+          'nested.0.bar': {
+            isNotEmpty: true,
+          },
+        })
+      })
     })
-    const res = mockRes()
-    const next = jest.fn()
 
-    // Assuming validate function setup
-    const middleware = validate({
-      body: BodyDTO,
-      params: ParamsDTO,
-      query: QueryDTO,
-    })
+    describe('field validation', () => {
+      class TestModel {
+        @IsNotEmpty()
+        title: string
 
-    middleware(req, res, next)
+        @IsNotEmpty()
+        anotherString: string
 
-    // Expectations about the next call and req modifications
-    expect(next).toHaveBeenCalled()
-    expect(req.errors).toEqual({
-      body: { name: { isNotEmpty: true } },
-      params: { id: { isInt: true, min: true } },
-      query: { search: { minLength: true } },
+        @IsInt()
+        selectedNumber: string
+      }
+
+      it('should return no errors when field validation passes', () => {
+        const test = {
+          title: 'a test title',
+          anotherString: 'another test string',
+          selectedNumber: 4,
+        }
+
+        const errors = getValidationErrors(test, TestModel)
+        expect(errors).toEqual({})
+      })
+
+      it('should return no errors when field validation passes', () => {
+        const test = {
+          title: 'a test title',
+          selectedNumber: 'should be a number',
+        }
+
+        const errors = getValidationErrors(test, TestModel)
+        expect(errors).toEqual({
+          anotherString: {
+            isNotEmpty: true,
+          },
+          selectedNumber: {
+            isInt: true,
+          },
+        })
+      })
     })
   })
 
-  it('should pass validation with no errors and call next', () => {
-    const req = mockReq({
-      body: { name: 'Mr. Egg' },
-      params: { id: 3 },
-      query: { search: 'justLongEnough' },
+  describe('validateRequest', () => {
+    class BodyDTO {
+      @IsNotEmpty()
+      name: string
+    }
+
+    class ParamsDTO {
+      @IsInt()
+      @Min(3)
+      id: number
+    }
+
+    class QueryDTO {
+      @MinLength(9)
+      search: string
+    }
+
+    it('should attach errors to req and call next', () => {
+      const req = mockReq({
+        body: { name: '' },
+        params: { id: 'abc' },
+        query: { search: 'tooShort' },
+      })
+      const res = mockRes()
+      const next = jest.fn()
+
+      // Assuming validate function setup
+      const middleware = validate({
+        body: BodyDTO,
+        params: ParamsDTO,
+        query: QueryDTO,
+      })
+
+      middleware(req, res, next)
+
+      // Expectations about the next call and req modifications
+      expect(next).toHaveBeenCalled()
+      expect(req.errors).toEqual({
+        body: { name: { isNotEmpty: true } },
+        params: { id: { isInt: true, min: true } },
+        query: { search: { minLength: true } },
+      })
     })
-    const res = mockRes()
-    const next = jest.fn()
 
-    const middleware = validate({
-      body: BodyDTO,
-      params: ParamsDTO,
-      query: QueryDTO,
-    })
+    it('should pass validation with no errors and call next', () => {
+      const req = mockReq({
+        body: { name: 'Mr. Egg' },
+        params: { id: 3 },
+        query: { search: 'justLongEnough' },
+      })
+      const res = mockRes()
+      const next = jest.fn()
 
-    middleware(req, res, next)
+      const middleware = validate({
+        body: BodyDTO,
+        params: ParamsDTO,
+        query: QueryDTO,
+      })
 
-    expect(next).toHaveBeenCalled()
-    expect(req.errors).toEqual({
-      body: {},
-      params: {},
-      query: {},
+      middleware(req, res, next)
+
+      expect(next).toHaveBeenCalled()
+      expect(req.errors).toEqual({
+        body: {},
+        params: {},
+        query: {},
+      })
     })
   })
 })

--- a/server/middleware/validationMiddleware.ts
+++ b/server/middleware/validationMiddleware.ts
@@ -1,6 +1,7 @@
 import { ClassConstructor, plainToInstance } from 'class-transformer'
 import { validateSync, ValidationError } from 'class-validator'
-import { Request, Response, NextFunction } from 'express'
+import { NextFunction, Request, Response } from 'express'
+import 'reflect-metadata'
 
 enum DataSources {
   BODY = 'body',
@@ -8,14 +9,31 @@ enum DataSources {
   QUERY = 'query',
 }
 
-function simplifyValidationErrors(errors: ValidationError[]): any {
-  const result: any = {}
-  errors.forEach(error => {
-    result[error.property] = error.constraints
-      ? Object.keys(error.constraints).reduce((acc, key) => ({ ...acc, [key]: true }), {})
-      : {}
-  })
-  return result
+function simplifyValidationErrors(errorsList: ValidationError[]): Record<string, any> {
+  function buildPrettyError(errorsInner: ValidationError[], path: string = ''): Record<string, any> {
+    return errorsInner.reduce((accumulator, error) => {
+      const currentPath = path ? `${path}.${error.property}` : error.property
+
+      const updatedAccumulator = {
+        ...accumulator,
+        ...(error.constraints && {
+          [currentPath]: Object.keys(error.constraints).reduce(
+            (constraintAccumulator, key) => ({ ...constraintAccumulator, [key]: true }),
+            {} as Record<string, boolean>,
+          ),
+        }),
+      }
+
+      if (error.children && error.children.length > 0) {
+        const childErrors = buildPrettyError(error.children, currentPath)
+        return { ...updatedAccumulator, ...childErrors }
+      }
+
+      return updatedAccumulator
+    }, {})
+  }
+
+  return buildPrettyError(errorsList)
 }
 
 export function getValidationErrors<T>(objectToValidate: object, dtoClass: ClassConstructor<T>) {


### PR DESCRIPTION
- Added support for nested validations
- Nested validations can be done like
```
@Expose()
@ValidateNested()
@Transform(({ obj }) => {
  return Object.keys(obj)
    .filter(key => key.startsWith('nested-foo-'))
    .map(key => key.slice(-1))
    .map(row =>
      plainToInstance(TestNestedModel, {
        foo: obj[`nested-foo-${row}`],
        bar: obj[`nested-bar-${row}`],
      }),
    );
})
nested: TestNestedModel[];
  ```
  with the above turning data like
  ```
'nested-foo-1': 'Foo 1',
'nested-bar-1': 'Bar 1',
'nested-foo-2': 'Foo 2',
'nested-bar-2': 'Bar 2',
```
into nested: TestNestedModel[].

- Updated error formatting to support nested validations
```
{
  'nested.0.bar': {
    isNotEmpty: true
  }
}
```