### PR TITLE
Refactor the goal summary card to be driven by locale

### DIFF
--- a/server/utils/commonLocale.json
+++ b/server/utils/commonLocale.json
@@ -22,6 +22,22 @@
         "agreePlanButton": "Agree plan"
       }
     },
+    "goalSummaryCard": {
+      "info": {
+        "aimToAchieve": "Aim to achieve in {{ monthsDifference }} months ({{ targetDate }})"
+      },
+      "stepsList": {
+        "whoHeader": "Who will do this",
+        "whatHeader": "Step",
+        "statusHeader": "Status",
+        "noStepsAdded": "No steps added",
+        "addSteps": "Add steps"
+      },
+      "areaOfNeed": {
+        "mainAreaOfNeed": "Area of need: {{ areaOfNeed }}",
+        "relatedAreasOfNeed": "Also relates to: {{ relatedAreasOfNeed }}"
+      }
+    },
     "backLink": {
       "text": "Back"
     },

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -106,11 +106,6 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
     return false
   })
 
-  // Filter to format related area of need
-  njkEnv.addFilter('getRelatedAreaOfNeed', relatedAreaOfNeed => {
-    return relatedAreaOfNeed.map((item: any) => item.name)
-  })
-
   // get months difference
   njkEnv.addGlobal('getMonthsDifference', (creationDate: string, targetDate: string) => {
     const [creationYear, creationMonth] = creationDate.split('-').map(Number)

--- a/server/views/components/summary-card/goal-summary-card.njk
+++ b/server/views/components/summary-card/goal-summary-card.njk
@@ -14,8 +14,8 @@
         goal: goal,
         areaOfNeed: params.goal.areaOfNeed.name | lower,
         relatedAreasOfNeed: relatedAreasOfNeed | join(', ') | lower,
-        targetDate: params.goal.targetDate | formatSimpleDate,
-        monthsDifference: getMonthsDifference(params.goal.creationDate, params.goal.targetDate)
+        targetDate: (params.goal.targetDate | formatSimpleDate) if params.goal.targetDate,
+        monthsDifference: (getMonthsDifference(params.goal.creationDate, params.goal.targetDate)) if params.goal.targetDate
     }) %}
 
     <div class="goal-summary-card {%- if params.errorMessage %} goal-summary-card--error {% endif %}">

--- a/server/views/components/summary-card/goal-summary-card.njk
+++ b/server/views/components/summary-card/goal-summary-card.njk
@@ -5,6 +5,19 @@
 {% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
 
 {% macro goalSummaryCard(params) %}
+    {% set relatedAreasOfNeed = [] %}
+    {% for areaOfNeed in params.goal.relatedAreasOfNeed %}
+        {% set relatedAreasOfNeed = relatedAreasOfNeed.concat(areaOfNeed.name) %}
+    {% endfor %}
+
+    {% set locale = interpolate(params.locale.common.goalSummaryCard, {
+        goal: goal,
+        areaOfNeed: params.goal.areaOfNeed.name | lower,
+        relatedAreasOfNeed: relatedAreasOfNeed | join(', ') | lower,
+        targetDate: params.goal.targetDate | formatSimpleDate,
+        monthsDifference: getMonthsDifference(params.goal.creationDate, params.goal.targetDate)
+    }) %}
+
     <div class="goal-summary-card {%- if params.errorMessage %} goal-summary-card--error {% endif %}">
         {% if params.errorMessage %}
             {{govukTag({
@@ -24,7 +37,7 @@
             <div class="goal-summary-card__info">
                 {% if params.goal.targetDate %}
                     <p>
-                        Aim to achieve in {{ getMonthsDifference(params.goal.creationDate, params.goal.targetDate) }} months ({{ params.goal.targetDate | formatSimpleDate }})
+                        {{ locale.info.aimToAchieve }}
                     </p>
                 {% endif %}
                 {% if params.errorMessage %}
@@ -38,32 +51,32 @@
             <table class="govuk-table goal-summary-card__steps">
                 <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
-                    <th scope="col" class="govuk-table__header">Step</th>
-                    <th scope="col" class="govuk-table__header">Who will do this</th>
+                    <th scope="col" class="govuk-table__header">{{ locale.stepsList.whoHeader }}</th>
+                    <th scope="col" class="govuk-table__header">{{ locale.stepsList.whatHeader }}</th>
                 </tr>
                 </thead>
                 <tbody class="govuk-table__body">
                 {% for step in params.goal.steps %}
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">{{ step.description }}</td>
                         <td class="govuk-table__cell">{{ step.actor }}</td>
+                        <td class="govuk-table__cell">{{ step.description }}</td>
                     </tr>
                 {% endfor %}
                 </tbody>
             </table>
         {% else %}
             <div class="goal-summary-card__steps--empty">
-                <strong>No steps added</strong>
+                <strong>{{ locale.stepsList.noStepsAdded }}</strong>
                 {% if params.actions.length > 0 %}
-                    <a href="/goal/{{ params.goal.uuid }}/add-steps">Add steps</a>
+                    <a href="/goal/{{ params.goal.uuid }}/add-steps">{{ locale.stepsList.addSteps }}</a>
                 {% endif %}
             </div>
         {% endif %}
 
             <p class="goal-summary-card__areas-of-need">
-                Area of need: {{ params.goal.areaOfNeed.name | lower }}<br>
+                {{ locale.areaOfNeed.mainAreaOfNeed }}<br>
                 {% if params.goal.relatedAreasOfNeed.length > 0 %}
-                    Also relates to: {{ params.goal.relatedAreasOfNeed | getRelatedAreaOfNeed | join(', ') | lower }}
+                    {{ locale.areaOfNeed.relatedAreasOfNeed }}
                 {% endif %}
             </p>
 

--- a/server/views/components/summary-card/goal-summary-card.njk
+++ b/server/views/components/summary-card/goal-summary-card.njk
@@ -51,15 +51,15 @@
             <table class="govuk-table goal-summary-card__steps">
                 <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
-                    <th scope="col" class="govuk-table__header">{{ locale.stepsList.whoHeader }}</th>
                     <th scope="col" class="govuk-table__header">{{ locale.stepsList.whatHeader }}</th>
+                    <th scope="col" class="govuk-table__header">{{ locale.stepsList.whoHeader }}</th>
                 </tr>
                 </thead>
                 <tbody class="govuk-table__body">
                 {% for step in params.goal.steps %}
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">{{ step.actor }}</td>
                         <td class="govuk-table__cell">{{ step.description }}</td>
+                        <td class="govuk-table__cell">{{ step.actor }}</td>
                     </tr>
                 {% endfor %}
                 </tbody>

--- a/server/views/pages/plan-summary.njk
+++ b/server/views/pages/plan-summary.njk
@@ -181,7 +181,8 @@
                                     text: locale.goalSummaryCard.actions.removeGoal
                                 }
                             ],
-                            errorMessage: errorMessage
+                            errorMessage: errorMessage,
+                            locale: locale
                         }) }}
                     </li>
                 {% endfor %}

--- a/server/views/pages/remove-goal.njk
+++ b/server/views/pages/remove-goal.njk
@@ -20,7 +20,8 @@
         <h1 class="govuk-heading-l">{{ locale.mainHeading.title }}</h1>
 
         {{ goalSummaryCard({
-            goal: data.goal
+            goal: data.goal,
+            locale: locale
         }) }}
 
         <form id="remove-goal-form" method="POST">


### PR DESCRIPTION
- Refactor goal-summary-card in prep for SP2-619
- Modified to use strings from locale
  - note: `locale` now needs passing to the goalSummaryCard component, with the attribute `locale`