### PR TITLE
Adds authenticated user's ID to the username to be stored by the API

### DIFF
--- a/server/data/hmppsAuthClient.test.ts
+++ b/server/data/hmppsAuthClient.test.ts
@@ -7,7 +7,7 @@ import mockReq from '../testutils/preMadeMocks/mockReq'
 
 jest.mock('./tokenStore/redisTokenStore')
 
-const username = 'Dr.+Benjamin+Runolfsdottir'
+const username = 'a23ccacf-7160-4431-9b4d-c560be9c9f5c%7CDr.+Benjamin+Runolfsdottir'
 const token = { token: 'token-1', expiresAt: Date.now() - 30 * 1000 }
 const expiredToken = { token: 'token-1', expiresAt: Date.now() + 30 * 1000 }
 const tokenFromHmppsAuth = { user_name: 'Bob', access_token: 'token-2', expires_in: '300' }

--- a/server/data/hmppsAuthClient.ts
+++ b/server/data/hmppsAuthClient.ts
@@ -10,7 +10,7 @@ import { Token } from '../@types/Token'
 const timeoutSpec = config.apis.hmppsAuth.timeout
 const hmppsAuthUrl = config.apis.hmppsAuth.url
 
-function getSystemClientTokenFromHmppsAuth(username?: string): Promise<superagent.Response> {
+function getSystemClientTokenFromHmppsAuth(identifier: string, username?: string): Promise<superagent.Response> {
   const clientToken = generateOauthClientToken(
     config.apis.hmppsAuth.systemClientId,
     config.apis.hmppsAuth.systemClientSecret,
@@ -18,7 +18,7 @@ function getSystemClientTokenFromHmppsAuth(username?: string): Promise<superagen
 
   const grantRequest = new URLSearchParams({
     grant_type: 'client_credentials',
-    username, // todo
+    username: `${identifier}|${username}`,
   }).toString()
 
   logger.info(`${grantRequest} HMPPS Auth request for client id. '${config.apis.hmppsAuth.systemClientId}'`)
@@ -48,6 +48,7 @@ export default class HmppsAuthClient {
     }
 
     const newToken = await getSystemClientTokenFromHmppsAuth(
+      this.req.services.sessionService.getPrincipalDetails().identifier,
       this.req.services.sessionService.getPrincipalDetails().displayName,
     )
 


### PR DESCRIPTION
We need to store both the ID and the name of the authenticated user at the backend, so this PR sends the user GUID through concatenated with the user's name in the username field. We can't add another field because of various external authentication validation issues.