### PR TITLE
Addresses design review feedback

### DIFF
--- a/integration_tests/e2e/delete-goal.cy.ts
+++ b/integration_tests/e2e/delete-goal.cy.ts
@@ -78,13 +78,13 @@ describe('Delete a goal from a Plan before it has been agreed', () => {
     })
 
     it('When confirmed, goal is deleted', () => {
-      // Go to plan-summary page, check goal appears
+      // Go to plan overview page, check goal appears
       cy.visit(`/plan`)
       cy.get('.goal-list .goal-summary-card').should('have.length', 3).and('contain', goalData.title)
 
       // Click remove goal
       cy.contains('.goal-summary-card', goalData.title).within(() => {
-        cy.contains('a', 'Delete goal').click()
+        cy.contains('a', 'Delete').click()
       })
 
       // Check we've landed on confirm goal deletion page
@@ -97,7 +97,7 @@ describe('Delete a goal from a Plan before it has been agreed', () => {
       cy.contains('button', 'Confirm').click()
 
       // Check goal has been deleted
-      cy.url().should('contain', '/plan?type=current&status=removed')
+      cy.url().should('contain', '/plan?type=current&status=deleted')
       cy.get('.goal-list .goal-summary-card').should('have.length', 2).and('not.contain', goalData.title)
     })
   })

--- a/integration_tests/e2e/plan-overview.cy.ts
+++ b/integration_tests/e2e/plan-overview.cy.ts
@@ -74,7 +74,7 @@ describe('View Plan Overview', () => {
     cy.contains('.goal-summary-card', 'Accommodation').within(() => {
       cy.contains('a', 'Change goal')
       cy.contains('a', 'Add or change steps')
-      cy.contains('a', 'Delete goal')
+      cy.contains('a', 'Delete')
       cy.get('.govuk-tag').contains('Not started')
     })
   })

--- a/server/routes/planOverview/locale.json
+++ b/server/routes/planOverview/locale.json
@@ -14,6 +14,7 @@
       "addedGoal": "You added a goal to {{ subject.possessiveName }} plan.",
       "changedGoal": "You changed a goal in {{ subject.possessiveName }} plan.",
       "removedGoal": "You removed a goal from {{ subject.possessiveName }} plan.",
+      "deletedGoal": "You deleted a goal from {{ subject.possessiveName }} plan.",
       "achievedGoal": "Congratulations on achieving a goal, {{ subject.givenName }}"
     },
     "agreePlan": "{{ subject.givenName }} agreed to their plan on {{ plan.agreementDate }}",
@@ -38,13 +39,12 @@
         "draft": {
           "changeGoal": "Change goal",
           "addOrChangeSteps": "Add or change steps",
-          "deleteGoal": "Delete goal",
-          "removeGoal": "Remove goal"
+          "deleteGoal": "Delete"
         },
         "active": {
           "update": "Update",
           "markAsAchieved": "Mark as achieved",
-          "remove": "Remove"
+          "removeGoal": "Remove"
         },
         "achieved": {
           "viewDetails": "View details"

--- a/server/routes/removeGoal/RemoveGoalController.test.ts
+++ b/server/routes/removeGoal/RemoveGoalController.test.ts
@@ -72,7 +72,7 @@ describe('Test Deleting Goal', () => {
       req.body = { type: 'some-type', action: 'delete', goalUuid: 'xyz' }
       await controller.post(req as Request, res as Response, next)
       expect(req.services.goalService.deleteGoal).toHaveBeenCalled()
-      expect(res.redirect).toHaveBeenCalledWith(`${URLs.PLAN_OVERVIEW}?type=some-type&status=removed`)
+      expect(res.redirect).toHaveBeenCalledWith(`${URLs.PLAN_OVERVIEW}?type=some-type&status=deleted`)
     })
   })
 })
@@ -112,7 +112,7 @@ describe('Test Removing Goal', () => {
   })
 
   describe('post', () => {
-    it('should return to plan-summary after removing goal if remove goal is selected', async () => {
+    it('should return to plan overview after removing goal if remove goal is selected', async () => {
       req.body = { type: 'some-type', action: 'remove', goalUuid: 'xyz' }
       await controller.post(req as Request, res as Response, next)
       expect(req.services.goalService.updateGoal).toHaveBeenCalled()

--- a/server/routes/removeGoal/RemoveGoalController.ts
+++ b/server/routes/removeGoal/RemoveGoalController.ts
@@ -48,7 +48,7 @@ export default class RemoveGoalController {
       if (req.body.action === 'delete') {
         const response: superagent.Response = <superagent.Response>await req.services.goalService.deleteGoal(goalUuid)
         if (response.status === 204) {
-          return res.redirect(`${URLs.PLAN_OVERVIEW}?type=${type}&status=removed`)
+          return res.redirect(`${URLs.PLAN_OVERVIEW}?type=${type}&status=deleted`)
         }
       } else if (req.body.action === 'remove') {
         const goalData: Partial<NewGoal> = {

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -13,7 +13,7 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
   app.set('view engine', 'njk')
 
   app.locals.asset_path = '/assets/'
-  app.locals.applicationName = 'Sentence Plan'
+  app.locals.applicationName = 'Sentence plan'
   app.locals.environmentName = config.environmentName
   app.locals.environmentNameColour = config.environmentName === 'PRE-PRODUCTION' ? 'govuk-tag--green' : ''
 

--- a/server/views/pages/plan.njk
+++ b/server/views/pages/plan.njk
@@ -108,31 +108,14 @@
                 }) }}
             {% endif %}
 
-            {% if data.status == 'success' %}
+            {% if data.status and data.status in ['added', 'changed', 'removed', 'deleted', 'achieved'] %}
                 {{ mojBanner({
                     type: 'success',
-                    text: locale.notificationBanner.addedGoal,
-                    iconFallbackText: 'Success'
-                }) }}
-            {% elseif data.status == 'removed' %}
-                {{ mojBanner({
-                    type: 'success',
-                    text: locale.notificationBanner.removedGoal,
-                    iconFallbackText: 'Success'
-                }) }}
-            {% elseif data.status == 'updated' %}
-                {{ mojBanner({
-                    type: 'success',
-                    text: locale.notificationBanner.changedGoal,
-                    iconFallbackText: 'Success'
-                }) }}
-            {% elseif data.status == 'achieved' %}
-                {{ mojBanner({
-                    type: 'success',
-                    text: locale.notificationBanner.achievedGoal,
+                    text: locale.notificationBanner[data.status+'Goal'],
                     iconFallbackText: 'Success'
                 }) }}
             {% endif %}
+
             {% if data.plan.agreementStatus === 'AGREED' %}
                 <p class="govuk-body">{{ locale.agreePlan }}</p>
             {% elseif data.plan.agreementStatus === 'DO_NOT_AGREE' %}
@@ -242,7 +225,7 @@
                                 },
                                 {
                                     href: "/remove-goal/" + goal.uuid + "?type=current",
-                                    text: locale.goalSummaryCard.actions.active.remove
+                                    text: locale.goalSummaryCard.actions.active.removeGoal
                                 }
                             ] %}
                         {% elseif goal.status === 'ACHIEVED' %}

--- a/server/views/pages/remove-goal.njk
+++ b/server/views/pages/remove-goal.njk
@@ -43,7 +43,7 @@
                     name: "action",
                     value: data.actionType
                 }) }}
-                <a class="govuk-link govuk-link--no-visited-state" href="/plan-summary?type={{ data.type }}">{{ locale.cancelButtonText }}</a>
+                <a class="govuk-link govuk-link--no-visited-state" href="/plan?type={{ data.type }}">{{ locale.cancelButtonText }}</a>
             </div>
         </form>
     </div>


### PR DESCRIPTION
Addresses this feedback:

[x] ‘delete goal’ link should just be ‘delete’
[x] I get a 404 error when I click ‘Do not delete goal’ confused face 
[x] change the success banner to read ‘You deleted a goal from [Name]’s plan’ rather than removed?
[x] This has been fixed everywhere - The page title should be ‘Confirm you want to delete this goal - Sentence plan’. (It currently says ‘Sentence Plan’. 