### PR TITLE
Removes erroneous link

### DIFF
--- a/server/views/pages/plan.njk
+++ b/server/views/pages/plan.njk
@@ -239,7 +239,7 @@
                         {% elseif goal.status === 'REMOVED' %}
                             {% set actions = [
                                 {
-                                    href: '/view-achieved-goal/' + goal.uuid,
+                                    href: '#',
                                     text: locale.goalSummaryCard.actions.removed.viewDetails
                                 },
                                 {


### PR DESCRIPTION
Removes the link to "view achieved goal" from the actions when viewing a Removed Goal.