### PR TITLE
Changes behaviour to be correct :|

### DIFF
--- a/server/routes/changeGoal/ChangeGoalController.test.ts
+++ b/server/routes/changeGoal/ChangeGoalController.test.ts
@@ -376,7 +376,7 @@ describe('ChangeGoalController', () => {
       expect(res.redirect).toHaveBeenCalledWith(`/update-goal/${testGoal.uuid}`)
     })
 
-    it('should redirect to add-steps if Plan is agreed and future goal has no steps', async () => {
+    it('should redirect to add-steps if Plan is agreed and current goal has no steps', async () => {
       const draftPlanData: PlanType = { ...testPlan, agreementStatus: PlanAgreementStatus.AGREED }
       req.services.planService.getPlanByUuid = jest.fn().mockResolvedValue(draftPlanData)
 
@@ -387,7 +387,8 @@ describe('ChangeGoalController', () => {
         'goal-input-autocomplete': 'Goal for the future with no steps',
         'area-of-need': testGoal.areaOfNeed.name,
         'related-area-of-need-radio': 'no',
-        'start-working-goal-radio': 'no',
+        'start-working-goal-radio': 'yes',
+        'date-selection-radio': viewData.data.dateOptions[1].toISOString(),
       }
       req.errors = {
         body: {},

--- a/server/routes/changeGoal/ChangeGoalController.ts
+++ b/server/routes/changeGoal/ChangeGoalController.ts
@@ -55,7 +55,7 @@ export default class ChangeGoalController {
       if (plan.agreementStatus === PlanAgreementStatus.AGREED) {
         redirectTarget = `/update-goal/${goalUuid}`
 
-        if (type === 'future') {
+        if (type === 'current') {
           const goal = await req.services.goalService.getGoal(goalUuid)
           if (goal.steps.length === 0) {
             redirectTarget = `/goal/${goalUuid}/add-steps`


### PR DESCRIPTION
Should redirect to add-steps if a current goal has no steps, not a future goal.