### PR TITLE
SP2-915 View Plan Overview for Countersigning

### DIFF
--- a/integration_tests/e2e/countersign.cy.ts
+++ b/integration_tests/e2e/countersign.cy.ts
@@ -1,0 +1,28 @@
+import { AccessMode } from '../../server/@types/Handover'
+
+describe('View Plan Overview for READ_ONLY user', () => {
+  beforeEach(() => {
+    cy.createSentencePlan().then(planDetails => {
+      cy.openSentencePlan(planDetails.oasysAssessmentPk, AccessMode.READ_ONLY)
+    })
+  })
+
+  it('Should have one button', () => {
+    cy.visit('/plan')
+    cy.get('button').should('have.length', 0)
+    cy.get('[role="button"]').should('have.length', 1).and('contain', 'Return to OASys')
+  })
+
+  it('Visiting create-goal should fail', () => {
+    cy.visit('/create-goal/accommodation')
+    cy.url().should('include', '/plan')
+  })
+
+  it('Should have a `Return to OASys` button and it should return the user to the OASys return URL', () => {
+    cy.contains('a', 'Return to OASys').should('have.attr', 'href').and('include', Cypress.env('OASTUB_URL'))
+  })
+
+  it.skip('Should have no accessibility violations', () => {
+    cy.checkAccessibility()
+  })
+})

--- a/integration_tests/e2e/plan-overview.cy.ts
+++ b/integration_tests/e2e/plan-overview.cy.ts
@@ -2,7 +2,7 @@ import PlanOverview from '../pages/plan-overview'
 import { PlanType } from '../../server/@types/PlanType'
 import DataGenerator from '../support/DataGenerator'
 
-describe('View Plan Overview', () => {
+describe('View Plan Overview for READ_WRITE user', () => {
   const planOverview = new PlanOverview()
 
   beforeEach(() => {

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -10,7 +10,7 @@ declare namespace Cypress {
     ): Chainable<S>
 
     // Handover/Auth
-    openSentencePlan(oasysAssessmentPk: string): Chainable<T>
+    openSentencePlan(oasysAssessmentPk: string, accessMode: string): Chainable<T>
     createSentencePlan(): Chainable<T>
 
     // API

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -10,7 +10,7 @@ declare namespace Cypress {
     ): Chainable<S>
 
     // Handover/Auth
-    openSentencePlan(oasysAssessmentPk: string, accessMode: string): Chainable<T>
+    openSentencePlan(oasysAssessmentPk: string, accessMode?: string): Chainable<T>
     createSentencePlan(): Chainable<T>
 
     // API

--- a/integration_tests/support/commands/backend.ts
+++ b/integration_tests/support/commands/backend.ts
@@ -70,7 +70,7 @@ export const openSentencePlan = (oasysAssessmentPk, accessMode) => {
 }
 
 export const createSentencePlan = () => {
-  const oasysAssessmentPk = Math.random().toString(36).substring(2, 9)
+  const oasysAssessmentPk = Math.random().toString().substring(2, 9)
 
   return getApiToken().then(apiToken =>
     cy

--- a/integration_tests/support/commands/backend.ts
+++ b/integration_tests/support/commands/backend.ts
@@ -1,5 +1,6 @@
 import { NewGoal } from '../../../server/@types/NewGoalType'
 import { NewStep } from '../../../server/@types/StepType'
+import { AccessMode } from '../../../server/@types/Handover'
 
 const getApiToken = () => {
   const apiToken = Cypress.env('API_TOKEN')
@@ -27,34 +28,38 @@ const getApiToken = () => {
     })
 }
 
-export const openSentencePlan = oasysAssessmentPk => {
+function createHandoverContext(apiToken, oasysAssessmentPk, accessMode) {
+  return {
+    url: `${Cypress.env('ARNS_HANDOVER_URL')}/handover`,
+    method: 'POST',
+    auth: { bearer: apiToken },
+    body: {
+      oasysAssessmentPk,
+      user: {
+        identifier: 123,
+        displayName: 'Cypress User',
+        accessMode,
+        returnUrl: Cypress.env('OASTUB_URL'),
+      },
+      subjectDetails: {
+        crn: 'X123456',
+        pnc: '01/123456789A',
+        givenName: 'Sam',
+        familyName: 'Whitfield',
+        dateOfBirth: '1970-01-01',
+        gender: 0,
+        location: 'COMMUNITY',
+        sexuallyMotivatedOffenceHistory: 'NO',
+      },
+    },
+  }
+}
+
+export const openSentencePlan = (oasysAssessmentPk, accessMode) => {
   cy.session(oasysAssessmentPk, () =>
     getApiToken().then(apiToken =>
       cy
-        .request({
-          url: `${Cypress.env('ARNS_HANDOVER_URL')}/handover`,
-          method: 'POST',
-          auth: { bearer: apiToken },
-          body: {
-            oasysAssessmentPk,
-            user: {
-              identifier: 123,
-              displayName: 'Cypress User',
-              accessMode: 'READ_WRITE',
-              returnUrl: Cypress.env('OASTUB_URL'),
-            },
-            subjectDetails: {
-              crn: 'X123456',
-              pnc: '01/123456789A',
-              givenName: 'Sam',
-              familyName: 'Whitfield',
-              dateOfBirth: '1970-01-01',
-              gender: 0,
-              location: 'COMMUNITY',
-              sexuallyMotivatedOffenceHistory: 'NO',
-            },
-          },
-        })
+        .request(createHandoverContext(apiToken, oasysAssessmentPk, accessMode ?? AccessMode.READ_WRITE))
         .then(handoverResponse =>
           cy.visit(`${handoverResponse.body.handoverLink}?clientId=${Cypress.env('ARNS_HANDOVER_CLIENT_ID')}`),
         ),

--- a/server/@types/Handover.ts
+++ b/server/@types/Handover.ts
@@ -9,7 +9,7 @@ export type HandoverContextData = {
 export type HandoverPrincipal = {
   identifier: string
   displayName: string
-  accessMode: string
+  accessMode: AccessMode
   returnUrl?: string
 }
 
@@ -34,6 +34,11 @@ export type HandoverSentencePlanContext = {
   oasysAssessmentPk: string
   planId: string
   planVersion: number
+}
+
+export const enum AccessMode {
+  READ_WRITE = 'READ_WRITE',
+  READ_ONLY = 'READ_ONLY',
 }
 
 export const enum Gender {

--- a/server/middleware/authorisationMiddleware.test.ts
+++ b/server/middleware/authorisationMiddleware.test.ts
@@ -4,6 +4,7 @@ import authorisationMiddleware from './authorisationMiddleware'
 import mockReq from '../testutils/preMadeMocks/mockReq'
 import mockRes from '../testutils/preMadeMocks/mockRes'
 import handoverData from '../testutils/data/handoverData'
+import { AccessMode } from '../@types/Handover'
 
 jest.mock('../services/sessionService', () => {
   return jest.fn().mockImplementation(() => ({
@@ -22,7 +23,7 @@ describe('authorisationMiddleware', () => {
     next = jest.fn()
   })
 
-  it('should call next if principal details are present', async () => {
+  it('should call next if READ_WRITE principal details are present', async () => {
     ;(req.services.sessionService.getPrincipalDetails as jest.Mock).mockReturnValue({})
 
     const middleware = authorisationMiddleware()
@@ -32,6 +33,39 @@ describe('authorisationMiddleware', () => {
     expect(next).toHaveBeenCalled()
     expect(res.redirect).not.toHaveBeenCalled()
   })
+
+  it('should redirect to /sign-in if READ_ONLY principal details are present', async () => {
+    ;(req.services.sessionService.getPrincipalDetails as jest.Mock).mockReturnValue({
+      ...handoverData.principal,
+      accessMode: AccessMode.READ_ONLY,
+    })
+
+    const middleware = authorisationMiddleware()
+    middleware(req as Request, res as Response, next)
+
+    expect(req.services!.sessionService.getPrincipalDetails).toHaveBeenCalled()
+    expect(next).not.toHaveBeenCalled()
+    expect(res.redirect).toHaveBeenCalledWith('/sign-in')
+  })
+
+  it.each(['/create-goal', '/planning', 'plan?query=value'])(
+    'should redirect to /sign-in from %s if READ_ONLY principal details are present',
+    urlPath => {
+      ;(req.services.sessionService.getPrincipalDetails as jest.Mock).mockReturnValue({
+        ...handoverData.principal,
+        accessMode: AccessMode.READ_ONLY,
+      })
+
+      req.originalUrl = urlPath
+
+      const middleware = authorisationMiddleware()
+      middleware(req as Request, res as Response, next)
+
+      expect(req.services!.sessionService.getPrincipalDetails).toHaveBeenCalled()
+      expect(next).not.toHaveBeenCalled()
+      expect(res.redirect).toHaveBeenCalledWith('/sign-in')
+    },
+  )
 
   it('should redirect to /sign-in if principal details are not present', async () => {
     ;(req.services.sessionService.getPrincipalDetails as jest.Mock).mockReturnValue(null)

--- a/server/middleware/authorisationMiddleware.ts
+++ b/server/middleware/authorisationMiddleware.ts
@@ -7,7 +7,7 @@ export default function authorisationMiddleware(): RequestHandler {
     if (req.services.sessionService.getPrincipalDetails()) {
       if (
         req.services.sessionService.getPrincipalDetails().accessMode === AccessMode.READ_ONLY &&
-        !req.originalUrl.split('?')[0].startsWith(URLs.PLAN_OVERVIEW)
+        req.originalUrl.split('?')[0] !== URLs.PLAN_OVERVIEW
       ) {
         req.session.returnTo = req.originalUrl
         return res.redirect('/sign-in')

--- a/server/middleware/authorisationMiddleware.ts
+++ b/server/middleware/authorisationMiddleware.ts
@@ -7,7 +7,7 @@ export default function authorisationMiddleware(): RequestHandler {
     if (req.services.sessionService.getPrincipalDetails()) {
       if (
         req.services.sessionService.getPrincipalDetails().accessMode === AccessMode.READ_ONLY &&
-        req.originalUrl.split('?')[0] !== URLs.PLAN_OVERVIEW
+        req.originalUrl?.split('?')[0] !== URLs.PLAN_OVERVIEW
       ) {
         req.session.returnTo = req.originalUrl
         return res.redirect('/sign-in')

--- a/server/middleware/authorisationMiddleware.ts
+++ b/server/middleware/authorisationMiddleware.ts
@@ -1,8 +1,17 @@
 import type { RequestHandler } from 'express'
+import { AccessMode } from '../@types/Handover'
+import URLs from '../routes/URLs'
 
 export default function authorisationMiddleware(): RequestHandler {
   return (req, res, next) => {
     if (req.services.sessionService.getPrincipalDetails()) {
+      if (
+        req.services.sessionService.getPrincipalDetails().accessMode === AccessMode.READ_ONLY &&
+        !req.originalUrl.split('?')[0].startsWith(URLs.PLAN_OVERVIEW)
+      ) {
+        req.session.returnTo = req.originalUrl
+        return res.redirect('/sign-in')
+      }
       return next()
     }
 

--- a/server/routes/planOverview/PlanOverviewController.test.ts
+++ b/server/routes/planOverview/PlanOverviewController.test.ts
@@ -5,6 +5,8 @@ import mockRes from '../../testutils/preMadeMocks/mockRes'
 import locale from './locale.json'
 import testPlan from '../../testutils/data/planData'
 import runMiddlewareChain from '../../testutils/runMiddlewareChain'
+import testHandoverContext from '../../testutils/data/handoverData'
+import { AccessMode } from '../../@types/Handover'
 
 const oasysReturnUrl = 'https://oasys.return.url'
 
@@ -12,6 +14,7 @@ jest.mock('../../services/sessionService', () => {
   return jest.fn().mockImplementation(() => ({
     getPlanUUID: jest.fn().mockReturnValue(testPlan.uuid),
     getOasysReturnUrl: jest.fn().mockReturnValue(oasysReturnUrl),
+    getPrincipalDetails: jest.fn().mockReturnValue(testHandoverContext.principal),
     setReturnLink: jest.fn().mockImplementation,
   }))
 })
@@ -57,6 +60,16 @@ describe('PlanOverviewController', () => {
       await runMiddlewareChain(controller.get, req, res, next)
 
       expect(res.render).toHaveBeenCalledWith('pages/plan', viewData)
+    })
+
+    it('should render without validation errors when user is READ_ONLY', async () => {
+      req.services.sessionService.getPrincipalDetails = jest.fn().mockReturnValue({
+        ...testHandoverContext.principal,
+        accessMode: AccessMode.READ_ONLY,
+      })
+      await runMiddlewareChain(controller.get, req, res, next)
+
+      expect(res.render).toHaveBeenCalledWith('pages/countersign', viewData)
     })
 
     it('should permit valid type and status parameters', async () => {

--- a/server/routes/planOverview/PlanOverviewController.ts
+++ b/server/routes/planOverview/PlanOverviewController.ts
@@ -7,6 +7,7 @@ import validateRequest, { getValidationErrors } from '../../middleware/validatio
 import PlanModel from '../shared-models/PlanModel'
 import transformRequest from '../../middleware/transformMiddleware'
 import PlanOverviewQueryModel from './models/PlanOverviewQueryModel'
+import { AccessMode } from '../../@types/Handover'
 
 export default class PlanOverviewController {
   private render = async (req: Request, res: Response, next: NextFunction) => {
@@ -21,7 +22,13 @@ export default class PlanOverviewController {
 
       req.services.sessionService.setReturnLink(`/plan?type=${type ?? 'current'}`)
 
-      return res.render('pages/plan', {
+      let pageToRender = 'pages/plan'
+
+      if (req.services.sessionService.getPrincipalDetails().accessMode === AccessMode.READ_ONLY) {
+        pageToRender = 'pages/countersign'
+      }
+
+      return res.render(pageToRender, {
         locale: locale.en,
         data: {
           plan,

--- a/server/testutils/data/handoverData.ts
+++ b/server/testutils/data/handoverData.ts
@@ -1,11 +1,11 @@
-import { HandoverContextData } from '../../@types/Handover'
+import { AccessMode, HandoverContextData } from '../../@types/Handover'
 
 const testHandoverContext: HandoverContextData = {
   handoverSessionId: 'e7501b21-3951-426d-9a73-0c2c4527aa27',
   principal: {
     identifier: 'a23ccacf-7160-4431-9b4d-c560be9c9f5c',
     displayName: 'Dr. Benjamin Runolfsdottir',
-    accessMode: 'READ_WRITE',
+    accessMode: AccessMode.READ_WRITE,
     returnUrl: '',
   },
   subject: {

--- a/server/views/pages/countersign.njk
+++ b/server/views/pages/countersign.njk
@@ -1,7 +1,6 @@
 {% extends "../partials/layout.njk" %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "moj/components/sub-navigation/macro.njk" import mojSubNavigation %}
-{% from "moj/components/button-menu/macro.njk" import mojButtonMenu %}
 {%- from "moj/components/banner/macro.njk" import mojBanner -%}
 {% from "../components/summary-card/goal-summary-card.njk" import goalSummaryCard %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
@@ -59,28 +58,6 @@
 {% endblock %}
 
 {% set mainClasses = "app-container govuk-body" %}
-{% set header = {
-    type: "extended",
-    items: [
-        {
-            text: locale.header.returnToOasysButton,
-            href: data.oasysReturnUrl,
-            classes: "govuk-button--secondary",
-            type: 'button'
-        },
-        {
-            text: locale.header.createGoalButton,
-            href: "/create-goal/accommodation",
-            classes: "govuk-button--secondary",
-            type: 'button'
-        },
-        {
-            text: locale.header.agreePlanButton,
-            type: 'submit',
-            value: 'agree-plan'
-        } if data.plan.agreementStatus === 'DRAFT'
-    ]
-} %}
 
 {% block bodyStart %}
     <div id="top"></div>
@@ -89,7 +66,6 @@
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-
             {% if errors.domain %}
                 {{ govukErrorSummary({
                     titleText: "There is a problem",
@@ -99,14 +75,6 @@
                             href: "#goal-list"
                         }
                     ]
-                }) }}
-            {% endif %}
-
-            {% if data.status and data.status in ['added', 'changed', 'removed', 'deleted', 'achieved'] %}
-                {{ mojBanner({
-                    type: 'success',
-                    text: locale.notificationBanner[data.status+'Goal'],
-                    iconFallbackText: 'Success'
                 }) }}
             {% endif %}
 
@@ -168,22 +136,6 @@
                     {% set buttons = [] %}
                     {% set actions = [] %}
 
-                    {% if not loop.first %}
-                        {% set buttons = buttons.concat({
-                            text: locale.goalSummaryCard.buttons.moveUpButton,
-                            href: "/goals/" + goalType + "/" + goal.uuid + "/up",
-                            classes: "govuk-button--secondary"
-                        }) %}
-                    {% endif %}
-
-                    {% if not loop.last %}
-                        {% set buttons = buttons.concat({
-                            text: locale.goalSummaryCard.buttons.moveDownButton,
-                            href: "/goals/" + goalType + "/" + goal.uuid + "/down",
-                            classes: "govuk-button--secondary"
-                        }) %}
-                    {% endif %}
-
                     {% set errorMessage = false %}
                     {% if errors.domain['goals.' + item.index + '.steps'].arrayNotEmpty %}
                         {% set errorMessage = {
@@ -191,59 +143,6 @@
                             text: locale.errors['goal-summary-card'].arrayNotEmpty,
                             state: locale.goalSummaryCard.state.incomplete
                         } %}
-                    {% endif %}
-
-                    {% if data.plan.agreementStatus === 'DRAFT' %}
-                        {% set actions = [
-                            {
-                                href: "/change-goal/" + goal.uuid,
-                                text: locale.goalSummaryCard.actions.draft.changeGoal
-                            },
-                            {
-                                href: "/goal/" + goal.uuid + '/add-steps',
-                                text: locale.goalSummaryCard.actions.draft.addOrChangeSteps
-                            },
-                            {
-                                href: "/confirm-delete-goal/" + goal.uuid + "?type=current",
-                                text: locale.goalSummaryCard.actions.draft.deleteGoal
-                            }
-                        ] %}
-                    {% else %}
-                        {% if goal.status === 'ACTIVE' or goal.status === 'FUTURE' %}
-                            {% set actions = [
-                                {
-                                    href: "/update-goal/" + goal.uuid,
-                                    text: locale.goalSummaryCard.actions.active.update
-                                },
-                                {
-                                    href: "/confirm-achieved-goal/" + goal.uuid + "?type=current",
-                                    text: locale.goalSummaryCard.actions.active.markAsAchieved
-                                },
-                                {
-                                    href: "/remove-goal/" + goal.uuid + "?type=current",
-                                    text: locale.goalSummaryCard.actions.active.removeGoal
-                                }
-                            ] %}
-                        {% elseif goal.status === 'ACHIEVED' %}
-                            {% set actions = [
-                                {
-                                    href: '/view-achieved-goal/' + goal.uuid,
-                                    text: locale.goalSummaryCard.actions.achieved.viewDetails
-                                }
-                            ] %}
-                            {% set buttons = [] %}
-                        {% elseif goal.status === 'REMOVED' %}
-                            {% set actions = [
-                                {
-                                    href: '#',
-                                    text: locale.goalSummaryCard.actions.removed.viewDetails
-                                },
-                                {
-                                    href: '#',
-                                    text: locale.goalSummaryCard.actions.removed.addToPlan
-                                }
-                            ] %}
-                        {% endif %}
                     {% endif %}
 
                     <li>
@@ -257,16 +156,6 @@
                     </li>
                 {% endfor %}
             </ol>
-            {% endif %}
-
-            {% if goalType == 'current' and goals.length == 0 %}
-                <p>{{ locale.ifNoCurrentGoals.text }}</p>
-                <ul>
-                    <li><a href="/create-goal/accommodation" class="govuk-link govuk-link--no-visited-state">{{ locale.ifNoCurrentGoals.action1 }}</a></li>
-                    <li><a href="/about-pop" class="govuk-link govuk-link--no-visited-state">{{ locale.ifNoCurrentGoals.action2 }}</a></li>
-                </ul>
-            {% elseif goalType == 'future' and goals.length == 0 %}
-                <p>{{ locale.ifNoFutureGoals.text }}</p>
             {% endif %}
 
             {% include "../partials/back-to-top-link.njk" %}

--- a/server/views/pages/countersign.njk
+++ b/server/views/pages/countersign.njk
@@ -58,6 +58,17 @@
 {% endblock %}
 
 {% set mainClasses = "app-container govuk-body" %}
+{% set header = {
+    type: "extended",
+    items: [
+    {
+        text: locale.header.returnToOasysButton,
+        href: data.oasysReturnUrl,
+        classes: "govuk-button--secondary",
+        type: 'button'
+    }
+    ]
+} %}
 
 {% block bodyStart %}
     <div id="top"></div>


### PR DESCRIPTION
This PR redirects all users with an accessMode of READ_ONLY to the /plan URL when they try to access any URL (or back to sign-in if they haven't authorised yet). 

In PlanOverviewController the new countersign.njk template is rendered for a user with the READ_ONLY access mode. This removes all buttons except "Return to OASys" and removes all other goal/plan action links.

Reviewers can start with `server/middleware/authorisationMiddleware.ts` and `server/routes/planOverview/PlanOverviewController.ts`