### PR TITLE
SP2-407 Fixes sentence information durations

### DIFF
--- a/server/routes/aboutPop/locale.json
+++ b/server/routes/aboutPop/locale.json
@@ -7,6 +7,10 @@
       "title": "About {{ subject.givenName }}"
     },
     "detail": {
+      "sentenceHeading": "Sentence",
+      "endDateHeading": "Expected end date",
+      "unpaidWorkHeading": "Unpaid work",
+      "rarHeading": "RAR (Rehabilitation activity requirement)",
       "lastUpdated": "Last updated on {{ lastUpdatedDate }}.",
       "RoSH": "RoSH (Risk of Serious Harm)",
       "riskOfReoffending": "Risk of reoffending",

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -5,6 +5,7 @@ import {
   crimNeeds,
   crimNeedsOrdering,
 } from '../testutils/data/assessmentData'
+import commonLocale from './commonLocale.json'
 import locale from '../routes/aboutPop/locale.json'
 import {
   AssessmentArea,
@@ -13,7 +14,13 @@ import {
   AssessmentResponse,
   CriminogenicNeedsData,
 } from '../@types/Assessment'
-import { formatAssessmentData, groupAndSortOtherAreas, motivationText, yearsAndDaysElapsed } from './assessmentUtils'
+import {
+  formatAssessmentData,
+  groupAndSortOtherAreas,
+  motivationText,
+  sentenceLength,
+  yearsAndDaysElapsed,
+} from './assessmentUtils'
 
 describe('format assessment data', () => {
   it.each([
@@ -336,12 +343,28 @@ describe('replace motivation text', () => {
   })
 })
 
-describe('years and days elapsed', () => {
+describe('years, months and days elapsed', () => {
   it.each([
-    ['2024-11-06', '2029-01-12', '(4 years and 67 days)'],
-    [undefined, undefined, undefined],
-  ])('%s maps to %s', (from: string, to: string, expected: string) => {
-    expect(yearsAndDaysElapsed(from, to)).toEqual(expected)
+    ['2024-11-06', '2029-01-12', { days: 6, months: 2, years: 4 }],
+    ['2024-11-06', '2024-11-07', { days: 1, months: 0, years: 0 }],
+  ])('%s maps to %s', (from: string, to: string, expected: any) => {
+    expect(yearsAndDaysElapsed(from, to).values).toEqual(expected)
+  })
+})
+
+describe('sentence length', () => {
+  it.each([
+    ['2024-11-06', '2029-01-12', '4 years, 2 months and 6 days'],
+    ['2024-11-06', '2028-12-06', '4 years and 1 month'],
+    ['2024-11-06', '2029-11-12', '5 years and 6 days'],
+    ['2024-11-06', '2025-11-07', '1 year and 1 day'],
+    ['2024-11-06', '2025-01-12', '2 months and 6 days'],
+    ['2024-11-06', '2025-01-07', '2 months and 1 day'],
+    ['2024-11-06', '2024-11-07', '1 day'],
+    ['2024-11-06', '2025-01-06', '2 months'],
+    ['2024-11-06', '2027-11-06', '3 years'],
+  ])('%s to %s should be %s', (from: string, to: string, expected: any) => {
+    expect(sentenceLength(from, to, commonLocale.en.sentence)).toEqual(expected)
   })
 })
 

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -132,10 +132,42 @@ export const dateWithYear = (datetimeString: string): string | null => {
   return DateTime.fromISO(datetimeString).toFormat('d MMMM yyyy')
 }
 
-export const yearsAndDaysElapsed = (datetimeStringFrom: string, datetimeStringTo: string): string => {
+export const yearsAndDaysElapsed = (datetimeStringFrom: string, datetimeStringTo: string): any => {
   if (!datetimeStringFrom || isBlank(datetimeStringFrom)) return undefined
   if (!datetimeStringTo || isBlank(datetimeStringTo)) return undefined
-  const yearsDays = DateTime.fromISO(datetimeStringTo).diff(DateTime.fromISO(datetimeStringFrom), ['years', 'days'])
+  const yearsMonthsDays = DateTime.fromISO(datetimeStringTo).diff(DateTime.fromISO(datetimeStringFrom), [
+    'years',
+    'months',
+    'days',
+  ])
 
-  return `(${yearsDays.years} years and ${yearsDays.days} days)`
+  return yearsMonthsDays
+}
+
+const pluralise = (count: number, noun: string, suffix = 's'): string => {
+  return `${count} ${noun}${count !== 1 ? suffix : ''}`
+}
+
+// TODO add parameters to replace hardcoded words
+export const sentenceLength = (datetimeStringFrom: string, datetimeStringTo: string, locale: any): any => {
+  const yearsMonthsDays = yearsAndDaysElapsed(datetimeStringFrom, datetimeStringTo)
+  let sentenceLengthstring = ''
+
+  if (yearsMonthsDays.years > 0 && yearsMonthsDays.months > 0 && yearsMonthsDays.days > 0) {
+    sentenceLengthstring = `${pluralise(yearsMonthsDays.years, locale.year)}, ${pluralise(yearsMonthsDays.months, locale.month)} and ${pluralise(yearsMonthsDays.days, locale.day)}`
+  } else if (yearsMonthsDays.years > 0 && yearsMonthsDays.months > 0) {
+    sentenceLengthstring = `${pluralise(yearsMonthsDays.years, locale.year)} ${locale.conjunction} ${pluralise(yearsMonthsDays.months, locale.month)}`
+  } else if (yearsMonthsDays.months > 0 && yearsMonthsDays.days > 0) {
+    sentenceLengthstring = `${pluralise(yearsMonthsDays.months, locale.month)} ${locale.conjunction} ${pluralise(yearsMonthsDays.days, locale.day)}`
+  } else if (yearsMonthsDays.years > 0 && yearsMonthsDays.days > 0) {
+    sentenceLengthstring = `${pluralise(yearsMonthsDays.years, locale.year)} ${locale.conjunction} ${pluralise(yearsMonthsDays.days, locale.day)}`
+  } else if (yearsMonthsDays.years > 0) {
+    sentenceLengthstring = `${pluralise(yearsMonthsDays.years, locale.year)}`
+  } else if (yearsMonthsDays.months > 0) {
+    sentenceLengthstring = `${pluralise(yearsMonthsDays.months, locale.month)}`
+  } else if (yearsMonthsDays.days > 0) {
+    sentenceLengthstring = `${pluralise(yearsMonthsDays.days, locale.day)}`
+  }
+
+  return sentenceLengthstring
 }

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -148,7 +148,8 @@ const pluralise = (count: number, noun: string, suffix = 's'): string => {
   return `${count} ${noun}${count !== 1 ? suffix : ''}`
 }
 
-// TODO add parameters to replace hardcoded words
+// The sentence duration returned is in the form "x years, y months and z days" where any of year,month,date can
+// be 0, in which case it shouldn't be displayed and the formatting of the layout is updated accordingly.
 export const sentenceLength = (datetimeStringFrom: string, datetimeStringTo: string, locale: any): any => {
   const yearsMonthsDays = yearsAndDaysElapsed(datetimeStringFrom, datetimeStringTo)
   let sentenceLengthstring = ''

--- a/server/utils/commonLocale.json
+++ b/server/utils/commonLocale.json
@@ -75,7 +75,13 @@
     },
     "buttons": {},
     "links": {},
-    "footer": {}
+    "footer": {},
+    "sentence": {
+      "year": "year",
+      "month": "month",
+      "day": "day",
+      "conjunction": "and"
+    }
   },
   "cy": {}
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -6,7 +6,7 @@ import { ApplicationInfo } from '../applicationInfo'
 import config from '../config'
 import { initialiseName, mergeDeep, convertToTitleCase } from './utils'
 import commonLocale from './commonLocale.json'
-import { dateWithYear, yearsAndDaysElapsed } from './assessmentUtils'
+import { dateWithYear, sentenceLength } from './assessmentUtils'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -67,7 +67,7 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
   njkEnv.addFilter('initialiseName', initialiseName)
   njkEnv.addFilter('convertToTitleCase', convertToTitleCase)
   njkEnv.addFilter('dateWithYear', dateWithYear)
-  njkEnv.addGlobal('yearsAndDaysElapsed', yearsAndDaysElapsed)
+  njkEnv.addGlobal('sentenceLength', sentenceLength)
 
   // Filter to format date as 'Month YYYY'
   njkEnv.addFilter('formatMonthYear', date => {

--- a/server/views/pages/about.njk
+++ b/server/views/pages/about.njk
@@ -76,7 +76,7 @@
 
                 {% for sentence in data.deliusData.sentences %}
                     <tr class="govuk-table__row govuk-body-l">
-                        <td class = "govuk-table__cell govuk-padding-bottom--25 ">{{ sentence.description }} <br/> {{ yearsAndDaysElapsed(sentence.startDate, sentence.endDate) }} </td>
+                        <td class = "govuk-table__cell govuk-padding-bottom--25 ">{{ sentence.description }} <br/> ({{ sentenceLength(sentence.startDate, sentence.endDate, locale.common.sentence) }}) </td>
                         <td class = "govuk-table__cell govuk-padding-bottom--25">{{ sentence.endDate | formatSimpleDate }}</td>
                         <td class = "govuk-table__cell govuk-padding-bottom--25">
                             {% if sentence.unpaidWorkHoursOrdered > 0 %}

--- a/server/views/pages/about.njk
+++ b/server/views/pages/about.njk
@@ -68,10 +68,10 @@
             <table class="govuk-table govuk-!-margin-bottom-4" >
 
                 <tr class="govuk-body-s">
-                    <td class="govuk-padding-right--25">Sentence</td>
-                    <td class="govuk-padding-right--25">Expected end date</td>
-                    <td class="govuk-padding-right--25">Unpaid work</td>
-                    <td class="govuk-padding-right--25">Rehabilitation activity requirement (RAR)</td>
+                    <td class="govuk-padding-right--25">{{ locale.detail.sentenceHeading }}</td>
+                    <td class="govuk-padding-right--25">{{ locale.detail.endDateHeading }}</td>
+                    <td class="govuk-padding-right--25">{{ locale.detail.unpaidWorkHeading }}</td>
+                    <td class="govuk-padding-right--25">{{ locale.detail.rarHeading }}</td>
                 </tr>
 
                 {% for sentence in data.deliusData.sentences %}


### PR DESCRIPTION
Duration description are supposed to match the comment linked on this Jira story. This change supports displaying all combinations of years, months and days rather than just years and days.