### PR TITLE
SP2-700: Fixed steps being removed when pressing enter issue

### DIFF
--- a/integration_tests/e2e/add-steps.cy.ts
+++ b/integration_tests/e2e/add-steps.cy.ts
@@ -81,7 +81,7 @@ describe('Add Steps', () => {
       addStep.addStepAutocompleteText(2, secondStep.description)
       addStep.selectStepActor(2, secondStep.actor)
 
-      addStep.saveAndContinue()
+      addStep.saveAndContinuePressingEnter(2)
 
       cy.get('table.goal-summary-card__steps .govuk-table__body').children().should('have.length', 2)
       selectStepDescriptionByIndex(1).should('contain', firstStep.description)

--- a/integration_tests/e2e/add-steps.cy.ts
+++ b/integration_tests/e2e/add-steps.cy.ts
@@ -62,7 +62,7 @@ describe('Add Steps', () => {
       selectStepActorByIndex(1).should('contain', step.actor)
     })
 
-    it('Add one step, save, then add another', () => {
+    it('Add one step, save, then add 2 more', () => {
       cy.url().should('include', '/add-steps')
 
       const firstStep = DataGenerator.generateStep()
@@ -81,13 +81,21 @@ describe('Add Steps', () => {
       addStep.addStepAutocompleteText(2, secondStep.description)
       addStep.selectStepActor(2, secondStep.actor)
 
-      addStep.saveAndContinuePressingEnter(2)
+      addStep.AddAnotherStepPressingEnter(2)
 
-      cy.get('table.goal-summary-card__steps .govuk-table__body').children().should('have.length', 2)
+      const thirdStep = DataGenerator.generateStep()
+      addStep.addStepAutocompleteText(3, thirdStep.description)
+      addStep.selectStepActor(3, thirdStep.actor)
+
+      addStep.saveAndContinue()
+
+      cy.get('table.goal-summary-card__steps .govuk-table__body').children().should('have.length', 3)
       selectStepDescriptionByIndex(1).should('contain', firstStep.description)
       selectStepActorByIndex(1).should('contain', firstStep.actor)
       selectStepDescriptionByIndex(2).should('contain', secondStep.description)
       selectStepActorByIndex(2).should('contain', secondStep.actor)
+      selectStepDescriptionByIndex(3).should('contain', thirdStep.description)
+      selectStepActorByIndex(3).should('contain', thirdStep.actor)
     })
 
     it('Add multiple steps, removing one during creation', () => {

--- a/integration_tests/pages/add-steps.ts
+++ b/integration_tests/pages/add-steps.ts
@@ -19,6 +19,10 @@ export default class AddSteps {
     cy.get('button').contains('Save and continue').click()
   }
 
+  saveAndContinuePressingEnter = (position: number) => {
+    cy.get(`#step-description-${position}-autocomplete`).type('{enter}')
+  }
+
   removeStep(position: number) {
     cy.get(`button[value="remove-step-${position}"]`).click()
   }

--- a/integration_tests/pages/add-steps.ts
+++ b/integration_tests/pages/add-steps.ts
@@ -19,7 +19,7 @@ export default class AddSteps {
     cy.get('button').contains('Save and continue').click()
   }
 
-  saveAndContinuePressingEnter = (position: number) => {
+  AddAnotherStepPressingEnter = (position: number) => {
     cy.get(`#step-description-${position}-autocomplete`).type('{enter}')
   }
 

--- a/server/views/pages/add-steps.njk
+++ b/server/views/pages/add-steps.njk
@@ -60,6 +60,10 @@
     <input type="hidden" id="_areaOfNeed" value="{{ data.areaOfNeed }}"/>
     {% set steps = data.form.steps if data.form.steps and data.form.steps.length > 0 else [{}] %}
 
+    <div class="visually-hidden">
+                 <button value="save" type="submit" name="action" class="govuk-visually-hidden">Visually hidden submit button</button>
+    </div>
+
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <dl class="add-steps-list govuk-summary-list">

--- a/server/views/pages/add-steps.njk
+++ b/server/views/pages/add-steps.njk
@@ -60,9 +60,7 @@
     <input type="hidden" id="_areaOfNeed" value="{{ data.areaOfNeed }}"/>
     {% set steps = data.form.steps if data.form.steps and data.form.steps.length > 0 else [{}] %}
 
-    <div class="visually-hidden">
-                 <button value="add-step" type="submit" name="action" class="govuk-visually-hidden">Visually hidden add another step</button>
-    </div>
+    <button value="add-step" type="submit" name="action" class="govuk-visually-hidden">Visually hidden add another step</button>
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">

--- a/server/views/pages/add-steps.njk
+++ b/server/views/pages/add-steps.njk
@@ -60,7 +60,7 @@
     <input type="hidden" id="_areaOfNeed" value="{{ data.areaOfNeed }}"/>
     {% set steps = data.form.steps if data.form.steps and data.form.steps.length > 0 else [{}] %}
 
-    <button value="add-step" type="submit" name="action" class="govuk-visually-hidden">Visually hidden add another step</button>
+    <button aria-hidden="true" tabindex="-1" value="add-step" type="submit" name="action" class="govuk-visually-hidden">Visually hidden add another step</button>
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">

--- a/server/views/pages/add-steps.njk
+++ b/server/views/pages/add-steps.njk
@@ -61,7 +61,7 @@
     {% set steps = data.form.steps if data.form.steps and data.form.steps.length > 0 else [{}] %}
 
     <div class="visually-hidden">
-                 <button value="save" type="submit" name="action" class="govuk-visually-hidden">Visually hidden submit button</button>
+                 <button value="add-step" type="submit" name="action" class="govuk-visually-hidden">Visually hidden add another step</button>
     </div>
 
     <div class="govuk-grid-row">


### PR DESCRIPTION
This PR fixes a bug that would result in a step being removed when the user pressed enter. The issue was that the form selects the first form action on keypress. I have tried to change this to an <a> tag with no luck, it just stopped working all together.

The solution which seems to work is to have a copy of the Add another step button at the top of the form, visually hidden from the user. I have ran the fix against Axe which doesn't have any accessibility issues.