### PR TITLE
SP2-1053: Add clear option to add steps

### DIFF
--- a/integration_tests/e2e/add-steps.cy.ts
+++ b/integration_tests/e2e/add-steps.cy.ts
@@ -157,6 +157,27 @@ describe('Add Steps', () => {
       selectStepDescriptionByIndex(1).should('contain', firstStep.description)
       selectStepActorByIndex(1).should('contain', firstStep.actor)
     })
+
+    it('Add single step, pressing clear then repopulating', () => {
+      cy.url().should('include', '/add-steps')
+
+      const firstStep = DataGenerator.generateStep()
+      addStep.addStepAutocompleteText(1, firstStep.description)
+      addStep.selectStepActor(1, firstStep.actor)
+
+      addStep.clearStep()
+
+      const firstStepSecondPopulation = DataGenerator.generateStep()
+      addStep.addStepAutocompleteText(1, firstStepSecondPopulation.description)
+      addStep.selectStepActor(1, firstStepSecondPopulation.actor)
+
+      addStep.saveAndContinue()
+
+      cy.get('table.goal-summary-card__steps .govuk-table__body').children().should('have.length', 1)
+
+      selectStepDescriptionByIndex(1).should('contain', firstStepSecondPopulation.description)
+      selectStepActorByIndex(1).should('contain', firstStepSecondPopulation.actor)
+    })
   })
 
   describe('Error cases when adding steps', () => {

--- a/integration_tests/pages/add-steps.ts
+++ b/integration_tests/pages/add-steps.ts
@@ -26,4 +26,8 @@ export default class AddSteps {
   removeStep(position: number) {
     cy.get(`button[value="remove-step-${position}"]`).click()
   }
+
+  clearStep = () => {
+    cy.get(`button[value="clear-step-1"]`).click()
+  }
 }

--- a/server/routes/add-steps/AddStepsController.ts
+++ b/server/routes/add-steps/AddStepsController.ts
@@ -88,6 +88,22 @@ export default class AddStepsController {
     return next()
   }
 
+  private handleClearStep = (req: Request, res: Response, next: NextFunction) => {
+    if (req.body.action.startsWith('clear-step-')) {
+      const defaultStepValue = {
+        actor: req.services.sessionService.getSubjectDetails().givenName,
+        description: '',
+        status: StepStatus.NOT_STARTED,
+      }
+
+      req.body.steps.splice(0, 1, defaultStepValue)
+
+      return this.render(req, res, next)
+    }
+
+    return next()
+  }
+
   private handleAddStep = (req: Request, res: Response, next: NextFunction) => {
     if (req.body.action === 'add-step') {
       delete req.body.action
@@ -117,6 +133,7 @@ export default class AddStepsController {
       body: AddStepsPostModel,
     }),
     this.handleRemoveStep,
+    this.handleClearStep,
     this.handleAddStep,
     validateRequest(),
     this.handleValidationErrors,

--- a/server/routes/add-steps/locale.json
+++ b/server/routes/add-steps/locale.json
@@ -41,6 +41,7 @@
     "saveButtonText": "Save and continue",
     "addAnotherButton": "Add another step",
     "removeStepLinkButton": "Remove",
+    "clearStepLinkButton": "Clear",
     "errors": {
       "step-description": {
         "isNotEmpty": "Select or enter what they should do to achieve the goal.",

--- a/server/views/pages/add-steps.njk
+++ b/server/views/pages/add-steps.njk
@@ -140,9 +140,15 @@
                             }) }}
                         </dt>
                         <dt class="govuk-summary-list__value">
-                            <button value="remove-step-{{ loop.index }}" type="submit" name="action" class="govuk-link govuk-!-margin-bottom-0" data-module="govuk-button">
-                                {{ locale.removeStepLinkButton }}
+                            {% if steps|length > 1 %}
+                              <button value="remove-step-{{ loop.index }}" type="submit" name="action" class="govuk-link govuk-!-margin-bottom-0" data-module="govuk-button">
+                                  {{ locale.removeStepLinkButton }}
+                              </button>
+                            {% else %}
+                            <button value="clear-step-{{ loop.index }}" type="submit" name="action" class="govuk-link govuk-!-margin-bottom-0" data-module="govuk-button">
+                              {{ locale.clearStepLinkButton }}
                             </button>
+                            {% endif %}
                         </dt>
                     </div>
                 {% endfor %}


### PR DESCRIPTION
This change introduces a "Clear" option for when we only have a single step added to a goal. This does two things for us:

1. Is clearer to the user that they must have at least 1 step. They can clear the contents but must have one or more
2. Fixes a bug where removing all of the steps in a goal (when there were multiple) which would cause strange behaviour

<img width="1182" alt="Screenshot 2024-12-02 at 15 03 27" src="https://github.com/user-attachments/assets/437a3eba-3e3b-4097-a6cb-d1f21c351b5c">

<img width="1218" alt="Screenshot 2024-12-02 at 15 03 47" src="https://github.com/user-attachments/assets/3601834e-61b0-4346-909d-3aaa267333b8">

