### PR TITLE
Moves the brackets for sentence duration into the calculator from the template

### DIFF
--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -328,15 +328,15 @@ describe('years, months and days elapsed', () => {
 
 describe('sentence length', () => {
   it.each([
-    ['2024-11-06', '2029-01-12', '4 years, 2 months and 6 days'],
-    ['2024-11-06', '2028-12-06', '4 years and 1 month'],
-    ['2024-11-06', '2029-11-12', '5 years and 6 days'],
-    ['2024-11-06', '2025-11-07', '1 year and 1 day'],
-    ['2024-11-06', '2025-01-12', '2 months and 6 days'],
-    ['2024-11-06', '2025-01-07', '2 months and 1 day'],
-    ['2024-11-06', '2024-11-07', '1 day'],
-    ['2024-11-06', '2025-01-06', '2 months'],
-    ['2024-11-06', '2027-11-06', '3 years'],
+    ['2024-11-06', '2029-01-12', '(4 years, 2 months and 6 days)'],
+    ['2024-11-06', '2028-12-06', '(4 years and 1 month)'],
+    ['2024-11-06', '2029-11-12', '(5 years and 6 days)'],
+    ['2024-11-06', '2025-11-07', '(1 year and 1 day)'],
+    ['2024-11-06', '2025-01-12', '(2 months and 6 days)'],
+    ['2024-11-06', '2025-01-07', '(2 months and 1 day)'],
+    ['2024-11-06', '2024-11-07', '(1 day)'],
+    ['2024-11-06', '2025-01-06', '(2 months)'],
+    ['2024-11-06', '2027-11-06', '(3 years)'],
   ])('%s to %s should be %s', (from: string, to: string, expected: any) => {
     expect(sentenceLength(from, to, commonLocale.en.sentence)).toEqual(expected)
   })

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -337,6 +337,9 @@ describe('sentence length', () => {
     ['2024-11-06', '2024-11-07', '(1 day)'],
     ['2024-11-06', '2025-01-06', '(2 months)'],
     ['2024-11-06', '2027-11-06', '(3 years)'],
+    ['2024-11-06', undefined, undefined],
+    [undefined, '2027-11-06', undefined],
+    [undefined, undefined, undefined],
   ])('%s to %s should be %s', (from: string, to: string, expected: any) => {
     expect(sentenceLength(from, to, commonLocale.en.sentence)).toEqual(expected)
   })

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -190,5 +190,5 @@ export const sentenceLength = (datetimeStringFrom: string, datetimeStringTo: str
     sentenceLengthstring = `${pluralise(yearsMonthsDays.days, locale.day)}`
   }
 
-  return sentenceLengthstring
+  return `(${sentenceLengthstring})`
 }

--- a/server/views/pages/about.njk
+++ b/server/views/pages/about.njk
@@ -76,7 +76,7 @@
 
                 {% for sentence in data.deliusData.sentences %}
                     <tr class="govuk-table__row govuk-body-l">
-                        <td class = "govuk-table__cell govuk-padding-bottom--25 ">{{ sentence.description }} <br/> ({{ sentenceLength(sentence.startDate, sentence.endDate, locale.common.sentence) }}) </td>
+                        <td class = "govuk-table__cell govuk-padding-bottom--25 ">{{ sentence.description }} <br/> {{ sentenceLength(sentence.startDate, sentence.endDate, locale.common.sentence) }}</td>
                         <td class = "govuk-table__cell govuk-padding-bottom--25">{{ sentence.endDate | formatSimpleDate }}</td>
                         <td class = "govuk-table__cell govuk-padding-bottom--25">
                             {% if sentence.unpaidWorkHoursOrdered > 0 %}


### PR DESCRIPTION
If we leave the brackets in the template then when a sentence is missing an end date (which is a permitted state) you end up with `()` displaying on the About page.