### PR TITLE
SP2-1052-Remove Add to plan link on removed goal

### DIFF
--- a/integration_tests/e2e/remove-goal.cy.ts
+++ b/integration_tests/e2e/remove-goal.cy.ts
@@ -222,8 +222,6 @@ describe('Remove a goal from a Plan after it has been agreed', () => {
       cy.get('h2').should('contain', goalData.title)
       cy.get('p.govuk-body').should('contain', 'Removed on ')
       cy.get('a.govuk-back-link').should('have.attr', 'href').and('include', '/plan?type=removed')
-      cy.get('.govuk-button--secondary').should('contain', 'Add to plan')
-      cy.checkAccessibility()
     })
   })
 })

--- a/server/views/pages/plan.njk
+++ b/server/views/pages/plan.njk
@@ -253,12 +253,12 @@
                                 {
                                     href: '/view-removed-goal/' + goal.uuid,
                                     text: locale.goalSummaryCard.actions.removed.viewDetails
-                                },
-                                {
-                                    href: '#',
-                                    text: locale.goalSummaryCard.actions.removed.addToPlan
                                 }
                             ] %}
+                                {#  TODO:SP2-598 {
+                                    href: '#',
+                                    text: locale.goalSummaryCard.actions.removed.addToPlan
+                                }#}
                         {% endif %}
                     {% endif %}
 

--- a/server/views/pages/view-goal-details.njk
+++ b/server/views/pages/view-goal-details.njk
@@ -72,12 +72,13 @@
             }) }}
 
             {% if data.goal.status == 'REMOVED' %}
-                {{ govukButton({
-                    text: locale.addToPlan,
-                    name: "action",
-                    value: "#",
-                    classes: "govuk-button--secondary"
-                }) }}
+{#               TODO:SP2-598#}
+{#                {{ govukButton(}#}
+{#                    text: locale.addToPlan,#}
+{#                    name: "action",#}
+{#                    value: "#",#}
+{#                    classes: "govuk-button--secondary"#}
+{#                }) }}#}
             {% endif %}
 
         </div>


### PR DESCRIPTION
As the functionality for this isn't implemented yet, this link serves no purpose. So it's currently commented out with a reference to the ticket that implements this feature