### PR TITLE
Removes links to About Person page.

### DIFF
--- a/integration_tests/e2e/plan-overview.cy.ts
+++ b/integration_tests/e2e/plan-overview.cy.ts
@@ -26,7 +26,7 @@ describe('View Plan Overview for READ_WRITE user', () => {
 
   it('Should have text saying no goals to work on now', () => {
     cy.visit('/plan')
-    cy.get('.govuk-grid-column-full').should('contain', 'does not have any goals to work on now. You can either:')
+    cy.get('.govuk-grid-column-full').should('contain', 'does not have any goals to work on now.')
     cy.checkAccessibility()
   })
 

--- a/server/routes/planOverview/locale.json
+++ b/server/routes/planOverview/locale.json
@@ -27,8 +27,8 @@
       "removedGoals": "Removed goals ({{ goalCounts.removedGoals }})"
     },
     "ifNoCurrentGoals": {
-      "text": "{{ subject.givenName }} does not have any goals to work on now. You can either:",
-      "action1": "create a goal with {{ subject.givenName }}",
+      "text": "{{ subject.givenName }} does not have any goals to work on now.",
+      "action1": "Create a goal with {{ subject.givenName }}",
       "action2": "view information from {{ subject.possessiveName }} assessment"
     },
     "ifNoFutureGoals": {

--- a/server/views/pages/plan.njk
+++ b/server/views/pages/plan.njk
@@ -282,11 +282,7 @@
                             text: locale.errors['goals'].arrayNotEmpty
                         }) }}
                     {% endif %}
-                <p>{{ locale.ifNoCurrentGoals.text }}</p>
-                <ul>
-                    <li><a href="/create-goal/accommodation" class="govuk-link govuk-link--no-visited-state">{{ locale.ifNoCurrentGoals.action1 }}</a></li>
-                    <li><a href="/about" class="govuk-link govuk-link--no-visited-state">{{ locale.ifNoCurrentGoals.action2 }}</a></li>
-                </ul>
+                <p>{{ locale.ifNoCurrentGoals.text }} <a href="/create-goal/accommodation" class="govuk-link govuk-link--no-visited-state">{{ locale.ifNoCurrentGoals.action1 }}</a>.</p>
                 </div>
             {% elseif goalType == 'future' and goals.length == 0 %}
                 <p>{{ locale.ifNoFutureGoals.text }}</p>

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -27,11 +27,6 @@
           text: locale.common.primaryNavigation.planHistoryText,
           href: '/plan-history',
           active: data.pageId == 'plan-history'
-        },
-        {
-          text: locale.common.primaryNavigation.aboutPopText,
-          href: '/about',
-          active: data.pageId == 'about'
         }
       ]
     }) }}


### PR DESCRIPTION
This PR removes "About" from the main navigation and updates the text on the page to match the design on SP2-1049.

![Screenshot 2024-12-05 at 16 17 37](https://github.com/user-attachments/assets/96d81703-6e5a-4594-ab16-ffd691047f79)
