### PR TITLE
Makes start of page markup match Plan History for spacing

### DIFF
--- a/server/views/pages/about.njk
+++ b/server/views/pages/about.njk
@@ -46,6 +46,10 @@
 
 {% block content %}
     {{ super() }}
+    {% if data.assessmentAreas.versionUpdatedAt %}
+        <p class="govuk-body govuk-!-margin-top-5">{{ locale.detail.lastUpdated }}</p>
+    {% endif %}
+
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             {% if errors.domain %}
@@ -57,10 +61,6 @@
                     titleText: "There is a problem",
                     errorList: errorList
                 }) }}
-            {% endif %}
-
-            {% if data.assessmentAreas.versionUpdatedAt %}
-                <p class="govuk-body">{{ locale.detail.lastUpdated }}</p>
             {% endif %}
 
             {% if data.deliusData.sentences.length > 0 %}


### PR DESCRIPTION
Before:

![Screenshot 2024-12-09 at 14 45 24](https://github.com/user-attachments/assets/8474bd2b-8e9f-485e-adeb-1e7f4152bb11)

After:

![Screenshot 2024-12-09 at 15 19 53](https://github.com/user-attachments/assets/e0c814f7-951a-4ccf-a7a9-206eb3576638)
