### PR TITLE
SP2-1114 - Add banner for maintenance announcements

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -121,4 +121,5 @@ export default {
   },
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   environmentName: get('ENVIRONMENT_NAME', ''),
+  announcementMessage: get('ANNOUNCEMENT_MESSAGE', false),
 }

--- a/server/middleware/nunjucks/nunjucksSetup.ts
+++ b/server/middleware/nunjucks/nunjucksSetup.ts
@@ -18,6 +18,7 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
   app.locals.applicationName = 'Sentence plan'
   app.locals.environmentName = config.environmentName
   app.locals.environmentNameColour = config.environmentName === 'PRE-PRODUCTION' ? 'govuk-tag--green' : ''
+  app.locals.announcementMessage = config.announcementMessage
 
   // Cachebusting version string
   if (production) {

--- a/server/views/pages/plan.njk
+++ b/server/views/pages/plan.njk
@@ -65,6 +65,7 @@
 {% set header = {
     type: "plan-extended",
     heading: locale.common.primaryNavigation.planLinkText,
+    announcementMessage: announcementMessage,
     items: [
         {
             text: locale.header.returnToOasysButton,

--- a/server/views/partials/plan-header/plan-header-mini.njk
+++ b/server/views/partials/plan-header/plan-header-mini.njk
@@ -1,3 +1,5 @@
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
 {% if data.popData %}
     <header class="plan-header" role="presentation">
         <div class="plan-header__subject-details">
@@ -17,6 +19,11 @@
                 </div>
             </dl>
         </div>
+
+        {{ govukNotificationBanner({
+          text: header.announcementMessage
+        }) if header.announcementMessage }}
+
         {% block extension %}
             {# Block for extended versions #}
         {% endblock %}


### PR DESCRIPTION
Banner can be controlled using the `ANNOUNCEMENT_MESSAGE` environment variable, so that we can manage this through the helm config without redeploying new versions