### PR TITLE
SP2-1032: Go back from Add or change steps page

### DIFF
--- a/integration_tests/e2e/create-goal.cy.ts
+++ b/integration_tests/e2e/create-goal.cy.ts
@@ -78,6 +78,20 @@ describe('Create a new Goal', () => {
     cy.checkAccessibility()
   })
 
+  it('Creates a new goal and checks back link on add steps page is correct', () => {
+    createGoalPage.createGoal('accommodation')
+    createGoalPage.selectGoalAutocompleteOption('I w', 'I will comply with the conditions of my tenancy agreement')
+    createGoalPage.selectRelatedAreasOfNeedRadio('no')
+    createGoalPage.selectStartWorkingRadio('yes')
+    createGoalPage.selectAchievementDateSomethingElse('4/4/3036')
+    createGoalPage.clickButton('Add steps')
+
+    cy.url().should('contain', '/add-steps?type=current')
+
+    cy.get('.govuk-back-link').should('have.attr', 'href').and('include', '/change-goal')
+    cy.checkAccessibility()
+  })
+
   it('Creates a new goal without steps', () => {
     createGoalPage.createGoal('accommodation')
     createGoalPage.selectGoalAutocompleteOption('I w', 'I will comply with the conditions of my tenancy agreement')

--- a/server/routes/add-steps/AddStepsController.test.ts
+++ b/server/routes/add-steps/AddStepsController.test.ts
@@ -217,7 +217,7 @@ describe('AddStepsController', () => {
       await runMiddlewareChain(controller.post, req, res, next)
 
       expect(req.services.stepService.saveAllSteps).toHaveBeenCalledWith(expectedData, 'some-goal-uuid')
-      expect(res.redirect).toHaveBeenCalledWith(`${URLs.PLAN_OVERVIEW}?type=current`)
+      expect(res.redirect).toHaveBeenCalledWith(`${URLs.PLAN_OVERVIEW}?status=success`)
       expect(next).not.toHaveBeenCalled()
     })
 

--- a/server/routes/add-steps/AddStepsController.test.ts
+++ b/server/routes/add-steps/AddStepsController.test.ts
@@ -217,7 +217,7 @@ describe('AddStepsController', () => {
       await runMiddlewareChain(controller.post, req, res, next)
 
       expect(req.services.stepService.saveAllSteps).toHaveBeenCalledWith(expectedData, 'some-goal-uuid')
-      expect(res.redirect).toHaveBeenCalledWith(`${URLs.PLAN_OVERVIEW}?status=success`)
+      expect(res.redirect).toHaveBeenCalledWith(`${URLs.PLAN_OVERVIEW}?type=current`)
       expect(next).not.toHaveBeenCalled()
     })
 

--- a/server/routes/add-steps/AddStepsController.ts
+++ b/server/routes/add-steps/AddStepsController.ts
@@ -59,8 +59,10 @@ export default class AddStepsController {
     try {
       await req.services.stepService.saveAllSteps(goalData, req.params.uuid)
 
-      const link = `${URLs.PLAN_OVERVIEW}?type=current`
-      req.services.sessionService.setReturnLink(null)
+      const link =
+        req.services.sessionService.getReturnLink() === `/change-goal/${req.params.uuid}/`
+          ? `${URLs.PLAN_OVERVIEW}?type=current`
+          : req.services.sessionService.getReturnLink()
 
       return res.redirect(link)
     } catch (e) {

--- a/server/routes/add-steps/AddStepsController.ts
+++ b/server/routes/add-steps/AddStepsController.ts
@@ -59,8 +59,7 @@ export default class AddStepsController {
     try {
       await req.services.stepService.saveAllSteps(goalData, req.params.uuid)
 
-      // TODO: this is wrong... we should be able to add steps only, or add steps after adding a (current or future) goal, and get a success banner...
-      const link = req.services.sessionService.getReturnLink() ?? `${URLs.PLAN_OVERVIEW}?status=success`
+      const link = `${URLs.PLAN_OVERVIEW}?type=current`
       req.services.sessionService.setReturnLink(null)
 
       return res.redirect(link)

--- a/server/routes/changeGoal/ChangeGoalController.test.ts
+++ b/server/routes/changeGoal/ChangeGoalController.test.ts
@@ -397,6 +397,31 @@ describe('ChangeGoalController', () => {
       expect(res.redirect).toHaveBeenCalledWith(`/update-goal-steps/${testGoal.uuid}`)
     })
 
+    it('should redirect to add-steps if came from add-steps and user clicked the back link', async () => {
+      const draftPlanData: PlanType = { ...testPlan, agreementStatus: PlanAgreementStatus.DRAFT }
+      req.services.planService.getPlanByUuid = jest.fn().mockResolvedValue(draftPlanData)
+
+      const testGoalWithNoSteps: Goal = { ...testGoal, steps: [] }
+      req.services.goalService.getGoal = jest.fn().mockReturnValue(testGoalWithNoSteps)
+      req.services.sessionService.getReturnLink = jest.fn().mockReturnValue(`/change-goal/${testGoal.uuid}/`)
+      req.services.sessionService.setReturnLink = jest.fn()
+
+      req.body = {
+        'goal-input-autocomplete': 'Goal for the future with no steps',
+        'area-of-need': testGoal.areaOfNeed.name,
+        'related-area-of-need-radio': 'no',
+        'start-working-goal-radio': 'yes',
+        'date-selection-radio': viewData.data.dateOptions[1].toISOString(),
+      }
+      req.errors = {
+        body: {},
+      }
+      req.params.uuid = testGoal.uuid
+
+      await runMiddlewareChain(controller.post, req, res, next)
+      expect(res.redirect).toHaveBeenCalledWith(`/goal/${testGoal.uuid}/add-steps`)
+    })
+
     it('should redirect to add-steps if Plan is agreed and current goal has no steps', async () => {
       const draftPlanData: PlanType = { ...testPlan, agreementStatus: PlanAgreementStatus.AGREED }
       req.services.planService.getPlanByUuid = jest.fn().mockResolvedValue(draftPlanData)

--- a/server/routes/changeGoal/ChangeGoalController.ts
+++ b/server/routes/changeGoal/ChangeGoalController.ts
@@ -63,7 +63,6 @@ export default class ChangeGoalController {
 
       // Check if the user has came back from the add-goals page
       if (req.services.sessionService.getReturnLink() === `/change-goal/${goalUuid}/`) {
-        req.services.sessionService.setReturnLink(null)
         redirectTarget = `/goal/${goalUuid}/add-steps`
       }
       if (plan.agreementStatus === PlanAgreementStatus.AGREED) {

--- a/server/routes/changeGoal/ChangeGoalController.ts
+++ b/server/routes/changeGoal/ChangeGoalController.ts
@@ -61,6 +61,11 @@ export default class ChangeGoalController {
       const planUuid = req.services.sessionService.getPlanUUID()
       const plan = await req.services.planService.getPlanByUuid(planUuid)
 
+      // Check if the user has came back from the add-goals page
+      if (req.services.sessionService.getReturnLink() === `/change-goal/${goalUuid}/`) {
+        req.services.sessionService.setReturnLink(null)
+        redirectTarget = `/goal/${goalUuid}/add-steps`
+      }
       if (plan.agreementStatus === PlanAgreementStatus.AGREED) {
         redirectTarget = `/update-goal-steps/${goalUuid}`
 

--- a/server/routes/createGoal/CreateGoalController.ts
+++ b/server/routes/createGoal/CreateGoalController.ts
@@ -22,6 +22,8 @@ export default class CreateGoalController {
     try {
       const { uuid } = await req.services.goalService.saveGoal(processedData, planUuid)
 
+      req.services.sessionService.setReturnLink(`/change-goal/${uuid}/`)
+
       if (req.body.action === 'addStep') {
         return res.redirect(`${URLs.ADD_STEPS.replace(':uuid', uuid)}?type=${type}`)
       }


### PR DESCRIPTION
Note: once we go back to the change goal page, using the back button. I would expect that we could press submit again and go once more to the add steps page, so have implemented this to get others opinions on it. Before making this change, clicking submit on the change-goal page would take us back to the plan overview, which doesn't seem right