### PR TITLE
Removes automatic redirection to confirm goal page

### DIFF
--- a/integration_tests/e2e/update-goal.cy.ts
+++ b/integration_tests/e2e/update-goal.cy.ts
@@ -101,15 +101,16 @@ describe('Update goal', () => {
       cy.checkAccessibility()
     })
 
-    it('Updating all step status to complete and saving goes to the achieve goal page', () => {
-      cy.get<Goal>('@goalForNow').then(goal => {
-        cy.visit(`/update-goal-steps/${goal.uuid}`)
-        cy.get('#step-status-1').select('Completed')
-        cy.get('.govuk-button').contains('Save goal and steps').click()
-        cy.url().should('include', `/confirm-achieved-goal/${goal.uuid}`)
-      })
-      cy.checkAccessibility()
-    })
+    // TODO SP2-633
+    // it('Updating all step status to complete and saving goes to the achieve goal page', () => {
+    //   cy.get<Goal>('@goalForNow').then(goal => {
+    //     cy.visit(`/update-goal-steps/${goal.uuid}`)
+    //     cy.get('#step-status-1').select('Completed')
+    //     cy.get('.govuk-button').contains('Save goal and steps').click()
+    //     cy.url().should('include', `/confirm-achieved-goal/${goal.uuid}`)
+    //   })
+    //   cy.checkAccessibility()
+    // })
 
     it('Can visit change goal and back link is correct', () => {
       cy.contains('a', 'Update').click()

--- a/server/routes/update-goal/UpdateGoalController.test.ts
+++ b/server/routes/update-goal/UpdateGoalController.test.ts
@@ -140,18 +140,19 @@ describe('UpdateGoalController', () => {
       expect(next).not.toHaveBeenCalled()
     })
 
-    it('should redirect to the achieve goal page when saved when all steps are completed', async () => {
-      req.body = {
-        'step-status-1': StepStatus.COMPLETED,
-        'step-uuid-1': testStep.uuid,
-        'more-detail': '',
-      }
-
-      await runMiddlewareChain(controller.post, req, res, next)
-
-      expect(res.redirect).toHaveBeenCalledWith(`${URLs.ACHIEVE_GOAL.replace(':uuid', testGoal.uuid)}`)
-      expect(next).not.toHaveBeenCalled()
-    })
+    // TODO SP2-633
+    // it('should redirect to the achieve goal page when saved when all steps are completed', async () => {
+    //   req.body = {
+    //     'step-status-1': StepStatus.COMPLETED,
+    //     'step-uuid-1': testStep.uuid,
+    //     'more-detail': '',
+    //   }
+    //
+    //   await runMiddlewareChain(controller.post, req, res, next)
+    //
+    //   expect(res.redirect).toHaveBeenCalledWith(`${URLs.ACHIEVE_GOAL.replace(':uuid', testGoal.uuid)}`)
+    //   expect(next).not.toHaveBeenCalled()
+    // })
 
     it('should redirect to the same page when a validation error occurs', async () => {
       req.body = {

--- a/server/routes/update-goal/UpdateGoalController.ts
+++ b/server/routes/update-goal/UpdateGoalController.ts
@@ -86,11 +86,14 @@ export default class UpdateGoalController {
 
       await this.updateSteps(req, goal, steps, note)
 
-      if (steps.length === 0 || steps.some((step: { status: string }) => step.status !== 'COMPLETED')) {
-        req.services.sessionService.setReturnLink(null)
-        return res.redirect(`${URLs.PLAN_OVERVIEW}?type=${goalType}`)
-      }
-      return res.redirect(`${URLs.ACHIEVE_GOAL.replace(':uuid', uuid)}`)
+      return res.redirect(`${URLs.PLAN_OVERVIEW}?type=${goalType}`)
+
+      // TODO SP2-633
+      // if (steps.length === 0 || steps.some((step: { status: string }) => step.status !== 'COMPLETED')) {
+      //   req.services.sessionService.setReturnLink(null)
+      //   return res.redirect(`${URLs.PLAN_OVERVIEW}?type=${goalType}`)
+      // }
+      // return res.redirect(`${URLs.ACHIEVE_GOAL.replace(':uuid', uuid)}`)
     } catch (e) {
       return next(HttpError(500, e.message))
     }


### PR DESCRIPTION
Removes automatic redirection to confirm goal page when all steps have been marked as complete. That is part of SP2-633, not this issue.

Rather than delete the relevant code it has been commented out ready to be restored when 633 is picked up, with relevant comments here and in Jira.