### PR TITLE
SP2-598 re-add goal to plan

### DIFF
--- a/integration_tests/e2e/about.cy.ts
+++ b/integration_tests/e2e/about.cy.ts
@@ -1,6 +1,6 @@
 import { AccessMode } from '../../server/@types/Handover'
 
-describe('Rendering READ_WRITE', () => {
+describe('Rendering About Person for READ_WRITE user', () => {
   beforeEach(() => {
     cy.createSentencePlan().then(planDetails => {
       cy.wrap(planDetails).as('plan')

--- a/integration_tests/e2e/plan-history.cy.ts
+++ b/integration_tests/e2e/plan-history.cy.ts
@@ -2,7 +2,7 @@ import PlanOverview from '../pages/plan-overview'
 import DataGenerator from '../support/DataGenerator'
 import { AccessMode } from '../../server/@types/Handover'
 
-describe('Rendering READ_WRITE', () => {
+describe('Rendering Plan History for READ_WRITE user', () => {
   const planOverview = new PlanOverview()
 
   beforeEach(() => {
@@ -104,7 +104,7 @@ describe('Rendering READ_WRITE', () => {
   })
 })
 
-describe('Rendering READ_ONLY', () => {
+describe('Rendering Plan History for READ_ONLY user', () => {
   const planOverview = new PlanOverview()
 
   beforeEach(() => {

--- a/integration_tests/e2e/re-add-goal.cy.ts
+++ b/integration_tests/e2e/re-add-goal.cy.ts
@@ -19,8 +19,15 @@ describe('Re-add a goal to a Plan after it has been removed', () => {
     })
   })
 
-  it('visit plan page', () => {
+  it('Remove goal details page contains button to re-add goal to plan OK', () => {
     cy.visit(`/view-removed-goal/${removedGoal.uuid}`)
-    cy.get('button.govuk-button--secondary').last().should('contain.text', 'Add to plan')
+    cy.get('a.add-to-plan').should('contain.text', 'Add to plan')
+  })
+
+  it('Clicking re-add goal to plan loads confirmation page', () => {
+    cy.visit(`/view-removed-goal/${removedGoal.uuid}`)
+    cy.get('a.add-to-plan').click()
+    cy.url().should('contain', `/confirm-add-goal/${removedGoal.uuid}`)
+    cy.title().should('contain', 'Confirm you want to add this goal back into the plan')
   })
 })

--- a/integration_tests/e2e/re-add-goal.cy.ts
+++ b/integration_tests/e2e/re-add-goal.cy.ts
@@ -1,0 +1,26 @@
+import DataGenerator from '../support/DataGenerator'
+import PlanOverview from '../pages/plan-overview'
+import { Goal } from '../../server/@types/GoalType'
+
+describe('Re-add a goal to a Plan after it has been removed', () => {
+  const planOverview = new PlanOverview()
+  let removedGoal: Goal
+
+  beforeEach(() => {
+    cy.createSentencePlan().then(planDetails => {
+      cy.openSentencePlan(planDetails.oasysAssessmentPk)
+
+      cy.addGoalToPlan(planDetails.plan.uuid, DataGenerator.generateGoal()).then(goal => {
+        cy.addStepToGoal(goal.uuid, DataGenerator.generateStep())
+        planOverview.agreePlan()
+        cy.removeGoalFromPlan(goal.uuid, 'A removal note')
+        removedGoal = goal
+      })
+    })
+  })
+
+  it('visit plan page', () => {
+    cy.visit(`/view-removed-goal/${removedGoal.uuid}`)
+    cy.get('button.govuk-button--secondary').last().should('contain.text', 'Add to plan')
+  })
+})

--- a/integration_tests/e2e/re-add-goal.cy.ts
+++ b/integration_tests/e2e/re-add-goal.cy.ts
@@ -14,6 +14,12 @@ describe('Re-add a goal to a Plan after it has been removed', () => {
         cy.removeGoalFromPlan(goal.uuid, 'A removal note')
         removedGoal = goal
       })
+
+      // add a second goal so that we can test that the order changes when adding back
+      // cy.addGoalToPlan(planDetails.plan.uuid, DataGenerator.generateGoal()).then(goal => {
+      //   cy.addStepToGoal(goal.uuid, DataGenerator.generateStep())
+      //   cy.agreePlan(planDetails.plan.uuid)
+      // })
     })
   })
 
@@ -58,6 +64,25 @@ describe('Re-add a goal to a Plan after it has been removed', () => {
     cy.get('button').contains('Confirm').click()
 
     cy.visit('/plan-history')
+    cy.get('.goal-status').first().should('contain.text', 'Goal added back into plan')
     cy.get('.goal-note').first().should('contain.text', RE_ADD_REASON)
+  })
+
+  it('Re-adding a goal puts it at the bottom of the goal list on the Plan Overview', () => {
+    const RE_ADD_REASON = 'A reason for re-adding the goal'
+
+    // add a second goal
+    // confirm that the one to remove is first
+    // TODO
+
+    cy.visit(`/view-removed-goal/${removedGoal.uuid}`)
+    cy.get('a.add-to-plan').click()
+    cy.get('#re-add-goal-reason').type(RE_ADD_REASON)
+    cy.get('input[name="start-working-goal-radio"][value="no"]').click()
+    cy.get('button').contains('Confirm').click()
+
+    // todo
+    // visit plan overview
+    // check order
   })
 })

--- a/integration_tests/e2e/re-add-goal.cy.ts
+++ b/integration_tests/e2e/re-add-goal.cy.ts
@@ -1,9 +1,7 @@
 import DataGenerator from '../support/DataGenerator'
-import PlanOverview from '../pages/plan-overview'
 import { Goal } from '../../server/@types/GoalType'
 
 describe('Re-add a goal to a Plan after it has been removed', () => {
-  const planOverview = new PlanOverview()
   let removedGoal: Goal
 
   beforeEach(() => {
@@ -12,7 +10,7 @@ describe('Re-add a goal to a Plan after it has been removed', () => {
 
       cy.addGoalToPlan(planDetails.plan.uuid, DataGenerator.generateGoal()).then(goal => {
         cy.addStepToGoal(goal.uuid, DataGenerator.generateStep())
-        planOverview.agreePlan()
+        cy.agreePlan(planDetails.plan.uuid)
         cy.removeGoalFromPlan(goal.uuid, 'A removal note')
         removedGoal = goal
       })

--- a/integration_tests/e2e/re-add-goal.cy.ts
+++ b/integration_tests/e2e/re-add-goal.cy.ts
@@ -28,4 +28,36 @@ describe('Re-add a goal to a Plan after it has been removed', () => {
     cy.url().should('contain', `/confirm-add-goal/${removedGoal.uuid}`)
     cy.title().should('contain', 'Confirm you want to add this goal back into the plan')
   })
+
+  it('Confirming re-add goal with target date loads plan overview on current goals tab', () => {
+    cy.visit(`/view-removed-goal/${removedGoal.uuid}`)
+    cy.get('a.add-to-plan').click()
+    cy.get('#re-add-goal-reason').type('A reason')
+    cy.get('input[name="start-working-goal-radio"][value="yes"]').click()
+    cy.get('label').contains('In 6 months').click()
+    cy.get('button').contains('Confirm').click()
+    cy.url().should('contain', `/plan?type=current`)
+  })
+
+  it('Confirming re-add goal without target date loads plan overview on future goals tab', () => {
+    cy.visit(`/view-removed-goal/${removedGoal.uuid}`)
+    cy.get('a.add-to-plan').click()
+    cy.get('#re-add-goal-reason').type('A reason')
+    cy.get('input[name="start-working-goal-radio"][value="no"]').click()
+    cy.get('button').contains('Confirm').click()
+    cy.url().should('contain', `/plan?type=future`)
+  })
+
+  it('Re-adding a goal adds a note to the Plan History', () => {
+    const RE_ADD_REASON = 'A reason for re-adding the goal'
+
+    cy.visit(`/view-removed-goal/${removedGoal.uuid}`)
+    cy.get('a.add-to-plan').click()
+    cy.get('#re-add-goal-reason').type(RE_ADD_REASON)
+    cy.get('input[name="start-working-goal-radio"][value="no"]').click()
+    cy.get('button').contains('Confirm').click()
+
+    cy.visit('/plan-history')
+    cy.get('.goal-note').first().should('contain.text', RE_ADD_REASON)
+  })
 })

--- a/integration_tests/e2e/re-add-goal.cy.ts
+++ b/integration_tests/e2e/re-add-goal.cy.ts
@@ -73,7 +73,7 @@ describe('Re-add a goal to a Plan after it has been removed', () => {
 
     // add a second goal
     // confirm that the one to remove is first
-    // TODO
+    // TODO PGW
 
     cy.visit(`/view-removed-goal/${removedGoal.uuid}`)
     cy.get('a.add-to-plan').click()
@@ -81,7 +81,7 @@ describe('Re-add a goal to a Plan after it has been removed', () => {
     cy.get('input[name="start-working-goal-radio"][value="no"]').click()
     cy.get('button').contains('Confirm').click()
 
-    // todo
+    // todo PGW
     // visit plan overview
     // check order
   })

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -17,6 +17,7 @@ declare namespace Cypress {
     addGoalToPlan(planUuid: string, goal: NewGoal): Chainable<Goal>
     addStepToGoal(goalUuid: string, step: NewStep): Chainable<Step>
     removeGoalFromPlan(goalUuid: string, note: string): Chainable<Goal>
+    agreePlan(planUuid: string): Chainable<Goal>
 
     lockPlan(planUuid: string): Chainable<T>
 

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -16,6 +16,7 @@ declare namespace Cypress {
     // API
     addGoalToPlan(planUuid: string, goal: NewGoal): Chainable<Goal>
     addStepToGoal(goalUuid: string, step: NewStep): Chainable<Step>
+    removeGoalFromPlan(goalUuid: string, note: string): Chainable<Goal>
 
     lockPlan(planUuid: string): Chainable<T>
 

--- a/integration_tests/support/commands/backend.ts
+++ b/integration_tests/support/commands/backend.ts
@@ -205,8 +205,10 @@ export const addGoalToPlan = (planUUid: string, goal: NewGoal) => {
 export const agreePlan = (planUUid: string) => {
   const agreement: PlanAgreement = {
     agreementStatus: PlanAgreementStatus.AGREED,
-    practitionerName: '',
-    personName: '',
+    practitionerName: 'Practitioner', // TODO real value
+    personName: 'Person', // TODO real value
+    agreementStatusNote: 'Plan was agreed',
+    optionalNote: '',
   }
 
   return getApiToken().then(apiToken =>

--- a/integration_tests/support/commands/backend.ts
+++ b/integration_tests/support/commands/backend.ts
@@ -2,6 +2,8 @@ import { NewGoal } from '../../../server/@types/NewGoalType'
 import { NewStep } from '../../../server/@types/StepType'
 import { AccessMode } from '../../../server/@types/Handover'
 import { GoalStatus } from '../../../server/@types/GoalType'
+import { PlanAgreement } from '../../../server/@types/PlanAgreement'
+import { PlanAgreementStatus } from '../../../server/@types/PlanType'
 
 const getApiToken = () => {
   const apiToken = Cypress.env('API_TOKEN')
@@ -195,6 +197,25 @@ export const addGoalToPlan = (planUUid: string, goal: NewGoal) => {
         method: 'POST',
         auth: { bearer: apiToken },
         body: goal,
+      })
+      .then(createResponse => createResponse.body),
+  )
+}
+
+export const agreePlan = (planUUid: string) => {
+  const agreement: PlanAgreement = {
+    agreementStatus: PlanAgreementStatus.AGREED,
+    practitionerName: '',
+    personName: '',
+  }
+
+  return getApiToken().then(apiToken =>
+    cy
+      .request({
+        url: `${Cypress.env('SP_API_URL')}/plans/${planUUid}/agree`,
+        method: 'POST',
+        auth: { bearer: apiToken },
+        body: agreement,
       })
       .then(createResponse => createResponse.body),
   )

--- a/integration_tests/support/commands/backend.ts
+++ b/integration_tests/support/commands/backend.ts
@@ -1,6 +1,7 @@
 import { NewGoal } from '../../../server/@types/NewGoalType'
 import { NewStep } from '../../../server/@types/StepType'
 import { AccessMode } from '../../../server/@types/Handover'
+import { GoalStatus } from '../../../server/@types/GoalType'
 
 const getApiToken = () => {
   const apiToken = Cypress.env('API_TOKEN')
@@ -192,6 +193,24 @@ export const addGoalToPlan = (planUUid: string, goal: NewGoal) => {
       .request({
         url: `${Cypress.env('SP_API_URL')}/plans/${planUUid}/goals`,
         method: 'POST',
+        auth: { bearer: apiToken },
+        body: goal,
+      })
+      .then(createResponse => createResponse.body),
+  )
+}
+
+export const removeGoalFromPlan = (goalUuid: string, note: string) => {
+  const goal: Partial<NewGoal> = {
+    status: GoalStatus.REMOVED,
+    note,
+  }
+
+  return getApiToken().then(apiToken =>
+    cy
+      .request({
+        url: `${Cypress.env('SP_API_URL')}/goals/${goalUuid}`,
+        method: 'PATCH',
         auth: { bearer: apiToken },
         body: goal,
       })

--- a/integration_tests/support/commands/backend.ts
+++ b/integration_tests/support/commands/backend.ts
@@ -4,6 +4,7 @@ import { AccessMode } from '../../../server/@types/Handover'
 import { GoalStatus } from '../../../server/@types/GoalType'
 import { PlanAgreement } from '../../../server/@types/PlanAgreement'
 import { PlanAgreementStatus } from '../../../server/@types/PlanType'
+import handoverData from '../../../server/testutils/data/handoverData'
 
 const getApiToken = () => {
   const apiToken = Cypress.env('API_TOKEN')
@@ -205,8 +206,8 @@ export const addGoalToPlan = (planUUid: string, goal: NewGoal) => {
 export const agreePlan = (planUUid: string) => {
   const agreement: PlanAgreement = {
     agreementStatus: PlanAgreementStatus.AGREED,
-    practitionerName: 'Practitioner', // TODO PGW real value
-    personName: 'Person', // TODO PGW real value
+    practitionerName: handoverData.principal.displayName,
+    personName: handoverData.subject.givenName,
     agreementStatusNote: 'Plan was agreed',
     optionalNote: '',
   }

--- a/integration_tests/support/commands/backend.ts
+++ b/integration_tests/support/commands/backend.ts
@@ -205,8 +205,8 @@ export const addGoalToPlan = (planUUid: string, goal: NewGoal) => {
 export const agreePlan = (planUUid: string) => {
   const agreement: PlanAgreement = {
     agreementStatus: PlanAgreementStatus.AGREED,
-    practitionerName: 'Practitioner', // TODO real value
-    personName: 'Person', // TODO real value
+    practitionerName: 'Practitioner', // TODO PGW real value
+    personName: 'Person', // TODO PGW real value
     agreementStatusNote: 'Plan was agreed',
     optionalNote: '',
   }

--- a/integration_tests/support/index.ts
+++ b/integration_tests/support/index.ts
@@ -1,4 +1,11 @@
-import { addGoalToPlan, addStepToGoal, createSentencePlan, lockPlan, openSentencePlan } from './commands/backend'
+import {
+  addGoalToPlan,
+  addStepToGoal,
+  removeGoalFromPlan,
+  createSentencePlan,
+  lockPlan,
+  openSentencePlan,
+} from './commands/backend'
 import { checkAccessibility } from './commands/accessibility'
 import 'cypress-axe'
 
@@ -9,6 +16,7 @@ Cypress.Commands.add('createSentencePlan', createSentencePlan)
 // API
 Cypress.Commands.add('addGoalToPlan', addGoalToPlan)
 Cypress.Commands.add('addStepToGoal', addStepToGoal)
+Cypress.Commands.add('removeGoalFromPlan', removeGoalFromPlan)
 
 Cypress.Commands.add('lockPlan', lockPlan)
 

--- a/integration_tests/support/index.ts
+++ b/integration_tests/support/index.ts
@@ -1,10 +1,11 @@
 import {
   addGoalToPlan,
   addStepToGoal,
-  removeGoalFromPlan,
+  agreePlan,
   createSentencePlan,
   lockPlan,
   openSentencePlan,
+  removeGoalFromPlan,
 } from './commands/backend'
 import { checkAccessibility } from './commands/accessibility'
 import 'cypress-axe'
@@ -17,6 +18,7 @@ Cypress.Commands.add('createSentencePlan', createSentencePlan)
 Cypress.Commands.add('addGoalToPlan', addGoalToPlan)
 Cypress.Commands.add('addStepToGoal', addStepToGoal)
 Cypress.Commands.add('removeGoalFromPlan', removeGoalFromPlan)
+Cypress.Commands.add('agreePlan', agreePlan)
 
 Cypress.Commands.add('lockPlan', lockPlan)
 

--- a/server/routes/URLs.ts
+++ b/server/routes/URLs.ts
@@ -14,4 +14,5 @@ export default {
   ACHIEVE_GOAL: '/confirm-achieved-goal/:uuid',
   AGREE_PLAN: '/agree-plan',
   PLAN_HISTORY: '/plan-history',
+  RE_ADD_GOAL: '/confirm-add-goal/:uuid',
 }

--- a/server/routes/achieveGoal/AchieveGoalController.test.ts
+++ b/server/routes/achieveGoal/AchieveGoalController.test.ts
@@ -27,7 +27,7 @@ jest.mock('../../services/sessionService', () => {
 jest.mock('../../services/sentence-plan/goalService', () => {
   return jest.fn().mockImplementation(() => ({
     getGoal: jest.fn().mockReturnValue(testGoal),
-    updateGoal: jest.fn().mockReturnValue(testGoal),
+    updateGoalStatus: jest.fn().mockReturnValue(testGoal),
   }))
 })
 
@@ -103,7 +103,7 @@ describe('AchieveGoalController', () => {
 
       await runMiddlewareChain(controller.post, req, res, next)
 
-      expect(req.services.goalService.updateGoal).toHaveBeenCalledWith(expectedPartialNewGoal, 'some-uuid')
+      expect(req.services.goalService.updateGoalStatus).toHaveBeenCalledWith(expectedPartialNewGoal, 'some-uuid')
       expect(res.redirect).toHaveBeenCalledWith('/plan?type=achieved&status=achieved')
       expect(next).not.toHaveBeenCalled()
     })

--- a/server/routes/achieveGoal/AchieveGoalController.ts
+++ b/server/routes/achieveGoal/AchieveGoalController.ts
@@ -47,7 +47,7 @@ export default class AchieveGoalController {
     }
 
     try {
-      await req.services.goalService.updateGoal(goalData, goalUuid)
+      await req.services.goalService.updateGoalStatus(goalData, goalUuid)
       return res.redirect(`/plan?type=achieved&status=achieved`)
     } catch (e) {
       return next(HttpError(500, e.message))

--- a/server/routes/changeGoal/ChangeGoalController.ts
+++ b/server/routes/changeGoal/ChangeGoalController.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, Response } from 'express'
 import locale from './locale.json'
 import URLs from '../URLs'
 import ReferentialDataService from '../../services/sentence-plan/referentialDataService'
-import { dateToISOFormat, formatDateWithStyle, getAchieveDateOptions } from '../../utils/utils'
+import { formatDateWithStyle, getAchieveDateOptions } from '../../utils/utils'
 import { Goal, GoalStatus } from '../../@types/GoalType'
 import transformRequest from '../../middleware/transformMiddleware'
 import ChangeGoalPostModel from './models/ChangeGoalPostModel'
@@ -12,6 +12,7 @@ import { requireAccessMode } from '../../middleware/authorisationMiddleware'
 import { AccessMode } from '../../@types/Handover'
 import { HttpError } from '../../utils/HttpError'
 import { NewGoal } from '../../@types/NewGoalType'
+import { getGoalTargetDate } from '../../utils/goalTargetDateUtils'
 
 export default class ChangeGoalController {
   constructor(private readonly referentialDataService: ReferentialDataService) {}
@@ -112,13 +113,11 @@ export default class ChangeGoalController {
 
   private processGoalData(body: any): Partial<NewGoal> {
     const title = body['goal-input-autocomplete']
-    const targetDate =
-      // eslint-disable-next-line no-nested-ternary
-      body['start-working-goal-radio'] === 'yes'
-        ? body['date-selection-radio'] === 'custom'
-          ? dateToISOFormat(body['date-selection-custom'])
-          : body['date-selection-radio']
-        : null
+    const targetDate = getGoalTargetDate(
+      body['start-working-goal-radio'],
+      body['date-selection-radio'],
+      body['date-selection-custom'],
+    )
     const areaOfNeed = body['area-of-need']
     const relatedAreasOfNeed = body['related-area-of-need-radio'] === 'yes' ? body['related-area-of-need'] : undefined
     const status = targetDate === null ? GoalStatus.FUTURE : undefined

--- a/server/routes/changeGoal/ChangeGoalController.ts
+++ b/server/routes/changeGoal/ChangeGoalController.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, Response } from 'express'
 import locale from './locale.json'
 import URLs from '../URLs'
 import ReferentialDataService from '../../services/sentence-plan/referentialDataService'
-import { formatDateWithStyle, getAchieveDateOptions } from '../../utils/utils'
+import { formatDateWithStyle } from '../../utils/utils'
 import { Goal, GoalStatus } from '../../@types/GoalType'
 import transformRequest from '../../middleware/transformMiddleware'
 import ChangeGoalPostModel from './models/ChangeGoalPostModel'
@@ -12,7 +12,7 @@ import { requireAccessMode } from '../../middleware/authorisationMiddleware'
 import { AccessMode } from '../../@types/Handover'
 import { HttpError } from '../../utils/HttpError'
 import { NewGoal } from '../../@types/NewGoalType'
-import { getGoalTargetDate } from '../../utils/goalTargetDateUtils'
+import { getDateOptions, getGoalTargetDate } from '../../utils/goalTargetDateUtils'
 
 export default class ChangeGoalController {
   constructor(private readonly referentialDataService: ReferentialDataService) {}
@@ -23,7 +23,7 @@ export default class ChangeGoalController {
 
     const sortedAreasOfNeed = this.referentialDataService.getSortedAreasOfNeed()
     const returnLink = req.services.sessionService.getReturnLink()
-    const dateOptions = this.getDateOptions()
+    const dateOptions = getDateOptions()
     const minimumDatePickerDate = formatDateWithStyle(new Date().toISOString(), 'short')
 
     try {
@@ -79,17 +79,12 @@ export default class ChangeGoalController {
     }
   }
 
-  private getDateOptions = () => {
-    const today = new Date()
-    return getAchieveDateOptions(today)
-  }
-
   private mapGoalToForm = (goal: Goal) => {
     let isCustomTargetDate = false
     let formattedTargetDate
 
     if (goal.targetDate) {
-      isCustomTargetDate = !this.getDateOptions().some(
+      isCustomTargetDate = !getDateOptions().some(
         dateOption => dateOption.toISOString().substring(0, 10) === goal.targetDate.substring(0, 10),
       )
 

--- a/server/routes/changeGoal/ChangeGoalController.ts
+++ b/server/routes/changeGoal/ChangeGoalController.ts
@@ -3,7 +3,6 @@ import locale from './locale.json'
 import URLs from '../URLs'
 import ReferentialDataService from '../../services/sentence-plan/referentialDataService'
 import { dateToISOFormat, formatDateWithStyle, getAchieveDateOptions } from '../../utils/utils'
-import { NewGoal } from '../../@types/NewGoalType'
 import { Goal, GoalStatus } from '../../@types/GoalType'
 import transformRequest from '../../middleware/transformMiddleware'
 import ChangeGoalPostModel from './models/ChangeGoalPostModel'
@@ -12,6 +11,7 @@ import { PlanAgreementStatus } from '../../@types/PlanType'
 import { requireAccessMode } from '../../middleware/authorisationMiddleware'
 import { AccessMode } from '../../@types/Handover'
 import { HttpError } from '../../utils/HttpError'
+import { NewGoal } from '../../@types/NewGoalType'
 
 export default class ChangeGoalController {
   constructor(private readonly referentialDataService: ReferentialDataService) {}
@@ -49,7 +49,7 @@ export default class ChangeGoalController {
 
   private saveAndRedirect = async (req: Request, res: Response, next: NextFunction) => {
     const goalUuid = req.params.uuid
-    const processedData: NewGoal = this.processGoalData(req.body)
+    const processedData: Partial<NewGoal> = this.processGoalData(req.body)
 
     const type = processedData.targetDate === null ? 'future' : 'current'
 
@@ -110,7 +110,7 @@ export default class ChangeGoalController {
     }
   }
 
-  private processGoalData(body: any) {
+  private processGoalData(body: any): Partial<NewGoal> {
     const title = body['goal-input-autocomplete']
     const targetDate =
       // eslint-disable-next-line no-nested-ternary

--- a/server/routes/changeGoal/locale.json
+++ b/server/routes/changeGoal/locale.json
@@ -20,27 +20,6 @@
         "no": "No"
       }
     },
-    "startWorking": {
-      "label": "Can {{ subject.givenName }} start working on this goal now?",
-      "options": {
-        "yes": "Yes",
-        "no": "No, it is a future goal"
-      }
-    },
-    "dateSelection": {
-      "label": "When should {{ subject.givenName }} aim to achieve this goal?",
-      "hint": "Select one option.",
-      "options": {
-        "threeMonths": "In 3 months ({{ dateOptions.threeMonths }})",
-        "sixMonths": "In 6 months ({{ dateOptions.sixMonths }})",
-        "twelveMonths": "In 12 months ({{ dateOptions.twelveMonths }})",
-        "custom": "Set another date"
-      }
-    },
-    "datePicker": {
-      "label": "Select a date",
-      "hint": "For example, 31/3/2024."
-    },
     "saveButtonText": "Save goal",
     "addStepsButton": "Add steps",
     "saveWithoutStepsButton": "Save without steps",

--- a/server/routes/createGoal/CreateGoalController.ts
+++ b/server/routes/createGoal/CreateGoalController.ts
@@ -3,14 +3,14 @@ import ReferentialDataService from '../../services/sentence-plan/referentialData
 import locale from './locale.json'
 import URLs from '../URLs'
 import { NewGoal } from '../../@types/NewGoalType'
-import { formatDateWithStyle, getAchieveDateOptions } from '../../utils/utils'
+import { formatDateWithStyle } from '../../utils/utils'
 import transformRequest from '../../middleware/transformMiddleware'
 import CreateGoalPostModel from './models/CreateGoalPostModel'
 import validateRequest from '../../middleware/validationMiddleware'
 import { requireAccessMode } from '../../middleware/authorisationMiddleware'
 import { AccessMode } from '../../@types/Handover'
 import { HttpError } from '../../utils/HttpError'
-import { getGoalTargetDate } from '../../utils/goalTargetDateUtils'
+import { getDateOptions, getGoalTargetDate } from '../../utils/goalTargetDateUtils'
 
 export default class CreateGoalController {
   constructor(private readonly referentialDataService: ReferentialDataService) {}
@@ -40,7 +40,7 @@ export default class CreateGoalController {
     const areasOfNeed = this.referentialDataService.getAreasOfNeed()
     const sortedAreasOfNeed = this.referentialDataService.getSortedAreasOfNeed()
 
-    const dateOptions = this.getDateOptions()
+    const dateOptions = getDateOptions()
     const selectedAreaOfNeed = areasOfNeed.find(areaOfNeed => areaOfNeed.url === req.params.areaOfNeed)
     const minimumDatePickerDate = formatDateWithStyle(new Date().toISOString(), 'short')
 
@@ -77,11 +77,6 @@ export default class CreateGoalController {
       targetDate,
       relatedAreasOfNeed,
     }
-  }
-
-  private getDateOptions = () => {
-    const today = new Date()
-    return getAchieveDateOptions(today)
   }
 
   private handleValidationErrors = (req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/createGoal/CreateGoalController.ts
+++ b/server/routes/createGoal/CreateGoalController.ts
@@ -3,13 +3,14 @@ import ReferentialDataService from '../../services/sentence-plan/referentialData
 import locale from './locale.json'
 import URLs from '../URLs'
 import { NewGoal } from '../../@types/NewGoalType'
-import { dateToISOFormat, formatDateWithStyle, getAchieveDateOptions } from '../../utils/utils'
+import { formatDateWithStyle, getAchieveDateOptions } from '../../utils/utils'
 import transformRequest from '../../middleware/transformMiddleware'
 import CreateGoalPostModel from './models/CreateGoalPostModel'
 import validateRequest from '../../middleware/validationMiddleware'
 import { requireAccessMode } from '../../middleware/authorisationMiddleware'
 import { AccessMode } from '../../@types/Handover'
 import { HttpError } from '../../utils/HttpError'
+import { getGoalTargetDate } from '../../utils/goalTargetDateUtils'
 
 export default class CreateGoalController {
   constructor(private readonly referentialDataService: ReferentialDataService) {}
@@ -62,13 +63,11 @@ export default class CreateGoalController {
 
   private processGoalData(body: any) {
     const title = body['goal-input-autocomplete']
-    let targetDate =
-      body['date-selection-radio'] === 'custom' && body['start-working-goal-radio'] === 'yes'
-        ? dateToISOFormat(body['date-selection-custom'])
-        : body['date-selection-radio']
-    if (body['start-working-goal-radio'] === 'no') {
-      targetDate = null
-    }
+    const targetDate = getGoalTargetDate(
+      body['start-working-goal-radio'],
+      body['date-selection-radio'],
+      body['date-selection-custom'],
+    )
     const areaOfNeed = body['area-of-need']
     const relatedAreasOfNeed = body['related-area-of-need-radio'] === 'yes' ? body['related-area-of-need'] : undefined
 

--- a/server/routes/createGoal/locale.json
+++ b/server/routes/createGoal/locale.json
@@ -21,26 +21,6 @@
         "no": "No"
       }
     },
-    "startWorking": {
-      "label": "Can {{ subject.givenName }} start working on this goal now?",
-      "options": {
-        "yes": "Yes",
-        "no": "No, it is a future goal"
-      }
-    },
-    "dateSelection": {
-      "label": "When should {{ subject.givenName }} aim to achieve this goal?",
-      "options": {
-        "threeMonths": "In 3 months ({{ dateOptions.threeMonths }})",
-        "sixMonths": "In 6 months ({{ dateOptions.sixMonths }})",
-        "twelveMonths": "In 12 months ({{ dateOptions.twelveMonths }})",
-        "custom": "Set another date"
-      }
-    },
-    "datePicker": {
-      "label": "Select a date",
-      "hint": "For example, 31/3/2023."
-    },
     "addStepsButton": "Add steps",
     "saveWithoutStepsButton": "Save without steps",
     "errors": {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -16,6 +16,7 @@ import setupAchieveGoalRoutes from './achieveGoal/routes'
 import setupUpdateGoalRoutes from './update-goal/routes'
 import setupViewGoalDetailsRoutes from './viewGoalDetails/routes'
 import setupPlanHistoryRoutes from './plan-history/routes'
+import setupReAddGoalRoutes from './reAddGoal/routes'
 
 export default function routes(services: Services): Router {
   const router = Router()
@@ -41,5 +42,6 @@ export default function routes(services: Services): Router {
   setupPlanOverviewRoutes(router)
   setupAgreePlanRoutes(router)
   setupPlanHistoryRoutes(router)
+  setupReAddGoalRoutes(router)
   return router
 }

--- a/server/routes/plan-history/locale.json
+++ b/server/routes/plan-history/locale.json
@@ -31,7 +31,7 @@
         },
         "goal": {
           "created": "Goal created",
-          "addedBackToPlan": "Goal added back to plan",
+          "addedBackToPlan": "Goal added back into plan",
           "removed": "Goal removed",
           "updated": "Goal updated",
           "achieved": "Goal marked as achieved"

--- a/server/routes/reAddGoal/ReAddGoalController.test.ts
+++ b/server/routes/reAddGoal/ReAddGoalController.test.ts
@@ -1,0 +1,112 @@
+import { NextFunction, Request, Response } from 'express'
+import testPlan from '../../testutils/data/planData'
+import mockReq from '../../testutils/preMadeMocks/mockReq'
+import mockRes from '../../testutils/preMadeMocks/mockRes'
+import locale from './locale.json'
+import testHandoverContext from '../../testutils/data/handoverData'
+import ReAddGoalController from './ReAddGoalController'
+import { testGoal } from '../../testutils/data/goalData'
+import { GoalStatus } from '../../@types/GoalType'
+import runMiddlewareChain from '../../testutils/runMiddlewareChain'
+
+jest.mock('../../middleware/authorisationMiddleware', () => ({
+  requireAccessMode: jest.fn(() => (req: Request, res: Response, next: NextFunction) => {
+    return next()
+  }),
+}))
+
+jest.mock('../../services/sessionService', () => {
+  return jest.fn().mockImplementation(() => ({
+    getPlanUUID: jest.fn().mockReturnValue(testPlan.uuid),
+    getPrincipalDetails: jest.fn().mockReturnValue(testHandoverContext.principal),
+    getSubjectDetails: jest.fn().mockReturnValue(testHandoverContext.subject),
+    getReturnLink: jest.fn().mockReturnValue('/some-return-link'),
+    setReturnLink: jest.fn(),
+  }))
+})
+
+jest.mock('../../services/sentence-plan/goalService', () => {
+  return jest.fn().mockImplementation(() => ({
+    getGoal: jest.fn().mockReturnValue(testGoal),
+    updateGoal: jest.fn().mockReturnValue(testGoal),
+  }))
+})
+
+jest.mock('../../services/sentence-plan/planService', () => {
+  return jest.fn().mockImplementation(() => ({
+    agreePlan: jest.fn().mockResolvedValue(testPlan),
+    getPlanByUuid: jest.fn().mockResolvedValue(testPlan),
+  }))
+})
+
+describe('AchieveGoalController', () => {
+  let controller: ReAddGoalController
+  let req: Request
+  let res: Response
+  let next: NextFunction
+  const viewData = {
+    data: {
+      returnLink: '/some-return-link',
+      form: {},
+      goal: testGoal,
+    },
+    errors: {},
+    locale: locale.en,
+  }
+
+  beforeEach(() => {
+    req = mockReq()
+    res = mockRes()
+    next = jest.fn()
+
+    controller = new ReAddGoalController()
+  })
+
+  describe('get', () => {
+    it('should render OK', async () => {
+      await runMiddlewareChain(controller.get, req, res, next)
+
+      expect(res.render).toHaveBeenCalledWith('pages/confirm-re-add-goal', viewData)
+    })
+
+    it('should render with validation errors', async () => {
+      const errors = {
+        body: { 'goal-achievement-helped': { maxLength: true } },
+        params: {},
+        query: {},
+      }
+      req.errors = errors
+      const expectedViewData = {
+        ...viewData,
+        errors,
+      }
+
+      await runMiddlewareChain(controller.get, req, res, next)
+
+      expect(res.render).toHaveBeenCalledWith('pages/confirm-re-add-goal', expectedViewData)
+    })
+  })
+
+  describe('post', () => {
+    it('should mark goal as achieved with optional note details', async () => {
+      req.params = {
+        uuid: 'some-uuid',
+        'goal-achievement-helped': 'Detail on how this goal helped',
+      }
+      req.body['goal-achievement-helped'] = 'Note body'
+
+      req.method = 'POST'
+
+      const expectedPartialNewGoal = {
+        status: GoalStatus.ACHIEVED,
+        note: 'Note body',
+      }
+
+      await runMiddlewareChain(controller.post, req, res, next)
+
+      expect(req.services.goalService.updateGoal).toHaveBeenCalledWith(expectedPartialNewGoal, 'some-uuid')
+      expect(res.redirect).toHaveBeenCalledWith('/plan?type=achieved&status=achieved')
+      expect(next).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/server/routes/reAddGoal/ReAddGoalController.test.ts
+++ b/server/routes/reAddGoal/ReAddGoalController.test.ts
@@ -29,7 +29,7 @@ jest.mock('../../services/sessionService', () => {
 jest.mock('../../services/sentence-plan/goalService', () => {
   return jest.fn().mockImplementation(() => ({
     getGoal: jest.fn().mockReturnValue(testGoal),
-    updateGoal: jest.fn().mockReturnValue(testGoal),
+    updateGoalStatus: jest.fn().mockReturnValue(testGoal),
   }))
 })
 
@@ -121,7 +121,7 @@ describe('AchieveGoalController', () => {
 
       await runMiddlewareChain(controller.post, req, res, next)
 
-      expect(req.services.goalService.updateGoal).toHaveBeenCalledWith(expectedPartialNewGoal, req.params.uuid)
+      expect(req.services.goalService.updateGoalStatus).toHaveBeenCalledWith(expectedPartialNewGoal, req.params.uuid)
       expect(res.redirect).toHaveBeenCalledWith(`/plan?type=${goalStatusToTabName(expectedPartialNewGoal.status)}`)
       expect(next).not.toHaveBeenCalled()
     })

--- a/server/routes/reAddGoal/ReAddGoalController.test.ts
+++ b/server/routes/reAddGoal/ReAddGoalController.test.ts
@@ -122,7 +122,6 @@ describe('AchieveGoalController', () => {
       await runMiddlewareChain(controller.post, req, res, next)
 
       expect(req.services.goalService.updateGoal).toHaveBeenCalledWith(expectedPartialNewGoal, req.params.uuid)
-      // todo use utils function to work out redirect location from goal.type
       expect(res.redirect).toHaveBeenCalledWith(`/plan?type=${goalStatusToTabName(expectedPartialNewGoal.status)}`)
       expect(next).not.toHaveBeenCalled()
     })

--- a/server/routes/reAddGoal/ReAddGoalController.ts
+++ b/server/routes/reAddGoal/ReAddGoalController.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Request, Response } from 'express'
-import { Goal, GoalStatus } from '../../@types/GoalType'
+import { GoalStatus } from '../../@types/GoalType'
 import locale from './locale.json'
 import validateRequest from '../../middleware/validationMiddleware'
 import transformRequest from '../../middleware/transformMiddleware'
@@ -42,9 +42,6 @@ export default class ReAddGoalController {
 
   private saveAndRedirect = async (req: Request, res: Response, next: NextFunction) => {
     const goalUuid = req.params.uuid
-
-    // retrieve full goal
-    const goal: Goal = await req.services.goalService.getGoal(goalUuid)
 
     const newGoal: Partial<NewGoal> = {}
 

--- a/server/routes/reAddGoal/ReAddGoalController.ts
+++ b/server/routes/reAddGoal/ReAddGoalController.ts
@@ -18,7 +18,6 @@ export default class ReAddGoalController {
     const { errors } = req
 
     try {
-      const type = req.query?.type
       const { uuid } = req.params
 
       const goal = await req.services.goalService.getGoal(uuid)
@@ -30,8 +29,6 @@ export default class ReAddGoalController {
       return res.render('pages/confirm-re-add-goal', {
         locale: locale.en,
         data: {
-          form: req.body,
-          type,
           dateOptions,
           returnLink,
           goal,
@@ -49,11 +46,7 @@ export default class ReAddGoalController {
     // retrieve full goal
     const goal: Goal = await req.services.goalService.getGoal(goalUuid)
 
-    const newGoal: NewGoal = {
-      title: goal.title,
-      areaOfNeed: goal.areaOfNeed.name,
-      relatedAreasOfNeed: goal.relatedAreasOfNeed.map(aon => aon.name),
-    }
+    const newGoal: Partial<NewGoal> = {}
 
     // set note
     newGoal.note = req.body['re-add-goal-reason']
@@ -84,7 +77,7 @@ export default class ReAddGoalController {
     return next()
   }
 
-  // todo duplicated from creategoalcontroller and changegoalcontroller
+  // TODO duplicated from creategoalcontroller and changegoalcontroller
   private getDateOptions = () => {
     const today = new Date()
     return getAchieveDateOptions(today)

--- a/server/routes/reAddGoal/ReAddGoalController.ts
+++ b/server/routes/reAddGoal/ReAddGoalController.ts
@@ -7,9 +7,9 @@ import ReAddGoalPostModel from './models/ReAddGoalPostModel'
 import { requireAccessMode } from '../../middleware/authorisationMiddleware'
 import { AccessMode } from '../../@types/Handover'
 import { HttpError } from '../../utils/HttpError'
-import { getAchieveDateOptions, goalStatusToTabName } from '../../utils/utils'
+import { goalStatusToTabName } from '../../utils/utils'
 import { NewGoal } from '../../@types/NewGoalType'
-import { getGoalTargetDate } from '../../utils/goalTargetDateUtils'
+import { getDateOptions, getGoalTargetDate } from '../../utils/goalTargetDateUtils'
 
 export default class ReAddGoalController {
   constructor() {}
@@ -22,7 +22,7 @@ export default class ReAddGoalController {
 
       const goal = await req.services.goalService.getGoal(uuid)
       const returnLink = req.services.sessionService.getReturnLink()
-      const dateOptions = this.getDateOptions()
+      const dateOptions = getDateOptions()
 
       req.services.sessionService.setReturnLink(`/plan?type=removed`)
 
@@ -52,7 +52,6 @@ export default class ReAddGoalController {
     newGoal.note = req.body['re-add-goal-reason']
 
     // set new targetDate
-    // TODO this is now in three files - extract it
     newGoal.targetDate = getGoalTargetDate(
       req.body['start-working-goal-radio'],
       req.body['date-selection-radio'],
@@ -75,12 +74,6 @@ export default class ReAddGoalController {
       return this.render(req, res, next)
     }
     return next()
-  }
-
-  // TODO duplicated from creategoalcontroller and changegoalcontroller
-  private getDateOptions = () => {
-    const today = new Date()
-    return getAchieveDateOptions(today)
   }
 
   get = [requireAccessMode(AccessMode.READ_WRITE), this.render]

--- a/server/routes/reAddGoal/ReAddGoalController.ts
+++ b/server/routes/reAddGoal/ReAddGoalController.ts
@@ -1,0 +1,75 @@
+import { NextFunction, Request, Response } from 'express'
+import { NewGoal } from '../../@types/NewGoalType'
+import { GoalStatus } from '../../@types/GoalType'
+import locale from './locale.json'
+import validateRequest from '../../middleware/validationMiddleware'
+import transformRequest from '../../middleware/transformMiddleware'
+import ReAddGoalPostModel from './models/ReAddGoalPostModel'
+import { requireAccessMode } from '../../middleware/authorisationMiddleware'
+import { AccessMode } from '../../@types/Handover'
+import { HttpError } from '../../utils/HttpError'
+
+export default class ReAddGoalController {
+  constructor() {}
+
+  private render = async (req: Request, res: Response, next: NextFunction) => {
+    const { errors } = req
+
+    try {
+      const type = req.query?.type
+      const { uuid } = req.params
+
+      const goal = await req.services.goalService.getGoal(uuid)
+      const returnLink = req.services.sessionService.getReturnLink()
+
+      req.services.sessionService.setReturnLink(`/plan?type=removed`)
+
+      return res.render('pages/confirm-re-add-goal', {
+        locale: locale.en,
+        data: {
+          form: req.body,
+          type,
+          returnLink,
+          goal,
+        },
+        errors,
+      })
+    } catch (e) {
+      return next(HttpError(500, e.message))
+    }
+  }
+
+  private saveAndRedirect = async (req: Request, res: Response, next: NextFunction) => {
+    const goalUuid = req.params.uuid
+    const note = req.body['goal-achievement-helped']
+
+    const goalData: Partial<NewGoal> = {
+      status: GoalStatus.ACHIEVED,
+      note,
+    }
+
+    try {
+      await req.services.goalService.updateGoal(goalData, goalUuid)
+      return res.redirect(`/plan?type=achieved&status=achieved`)
+    } catch (e) {
+      return next(HttpError(500, e.message))
+    }
+  }
+
+  private handleValidationErrors = (req: Request, res: Response, next: NextFunction) => {
+    if (Object.keys(req.errors?.body).length) {
+      return this.render(req, res, next)
+    }
+    return next()
+  }
+
+  get = [requireAccessMode(AccessMode.READ_WRITE), this.render]
+
+  post = [
+    requireAccessMode(AccessMode.READ_WRITE),
+    transformRequest({ body: ReAddGoalPostModel }),
+    validateRequest(),
+    this.handleValidationErrors,
+    this.saveAndRedirect,
+  ]
+}

--- a/server/routes/reAddGoal/ReAddGoalController.ts
+++ b/server/routes/reAddGoal/ReAddGoalController.ts
@@ -59,7 +59,7 @@ export default class ReAddGoalController {
     newGoal.status = newGoal.targetDate === null ? GoalStatus.FUTURE : GoalStatus.ACTIVE
 
     try {
-      await req.services.goalService.updateGoal(newGoal, goalUuid)
+      await req.services.goalService.updateGoalStatus(newGoal, goalUuid)
       return res.redirect(`/plan?type=${goalStatusToTabName(newGoal.status)}`)
     } catch (e) {
       return next(HttpError(500, e.message))

--- a/server/routes/reAddGoal/ReAddGoalController.ts
+++ b/server/routes/reAddGoal/ReAddGoalController.ts
@@ -70,7 +70,7 @@ export default class ReAddGoalController {
     newGoal.status = newGoal.targetDate === null ? GoalStatus.FUTURE : GoalStatus.ACTIVE
 
     try {
-      await req.services.goalService.replaceGoal(newGoal, goalUuid)
+      await req.services.goalService.updateGoal(newGoal, goalUuid)
       return res.redirect(`/plan?type=${goalStatusToTabName(newGoal.status)}`)
     } catch (e) {
       return next(HttpError(500, e.message))

--- a/server/routes/reAddGoal/ReAddGoalController.ts
+++ b/server/routes/reAddGoal/ReAddGoalController.ts
@@ -7,7 +7,7 @@ import ReAddGoalPostModel from './models/ReAddGoalPostModel'
 import { requireAccessMode } from '../../middleware/authorisationMiddleware'
 import { AccessMode } from '../../@types/Handover'
 import { HttpError } from '../../utils/HttpError'
-import { dateToISOFormat, getAchieveDateOptions } from '../../utils/utils'
+import { dateToISOFormat, getAchieveDateOptions, goalStatusToTabName } from '../../utils/utils'
 import { NewGoal } from '../../@types/NewGoalType'
 
 export default class ReAddGoalController {
@@ -68,13 +68,11 @@ export default class ReAddGoalController {
         : null
 
     // set new status
-    newGoal.status = goal.targetDate === null ? GoalStatus.FUTURE : GoalStatus.ACTIVE
+    newGoal.status = newGoal.targetDate === null ? GoalStatus.FUTURE : GoalStatus.ACTIVE
 
     try {
-      // probably need to use replaceGoal here - updateGoal is only good for status changes - should rename that function in GoalService.ts
       await req.services.goalService.replaceGoal(newGoal, goalUuid)
-      // TODO where does this go?
-      return res.redirect(`/plan`)
+      return res.redirect(`/plan?type=${goalStatusToTabName(newGoal.status)}`)
     } catch (e) {
       return next(HttpError(500, e.message))
     }

--- a/server/routes/reAddGoal/ReAddGoalController.ts
+++ b/server/routes/reAddGoal/ReAddGoalController.ts
@@ -7,8 +7,9 @@ import ReAddGoalPostModel from './models/ReAddGoalPostModel'
 import { requireAccessMode } from '../../middleware/authorisationMiddleware'
 import { AccessMode } from '../../@types/Handover'
 import { HttpError } from '../../utils/HttpError'
-import { dateToISOFormat, getAchieveDateOptions, goalStatusToTabName } from '../../utils/utils'
+import { getAchieveDateOptions, goalStatusToTabName } from '../../utils/utils'
 import { NewGoal } from '../../@types/NewGoalType'
+import { getGoalTargetDate } from '../../utils/goalTargetDateUtils'
 
 export default class ReAddGoalController {
   constructor() {}
@@ -59,13 +60,11 @@ export default class ReAddGoalController {
 
     // set new targetDate
     // TODO this is now in three files - extract it
-    newGoal.targetDate =
-      // eslint-disable-next-line no-nested-ternary
-      req.body['start-working-goal-radio'] === 'yes'
-        ? req.body['date-selection-radio'] === 'custom'
-          ? dateToISOFormat(req.body['date-selection-custom'])
-          : req.body['date-selection-radio']
-        : null
+    newGoal.targetDate = getGoalTargetDate(
+      req.body['start-working-goal-radio'],
+      req.body['date-selection-radio'],
+      req.body['date-selection-custom'],
+    )
 
     // set new status
     newGoal.status = newGoal.targetDate === null ? GoalStatus.FUTURE : GoalStatus.ACTIVE

--- a/server/routes/reAddGoal/locale.json
+++ b/server/routes/reAddGoal/locale.json
@@ -1,0 +1,21 @@
+{
+  "en": {
+    "page": {
+      "title": "Confirm you want to add this goal back into the plan - {{ applicationName }}",
+      "errorTitle": "Error: you want to add this goal back into the plan - {{ applicationName }}"
+    },
+    "mainHeading": {
+      "title": "Confirm you want to add this goal back into {{ subject.possessiveName }} plan"
+    },
+    "notes": {
+      "label": "How has achieving this goal helped {{ subject.givenName }}? (optional)"
+    },
+    "errors": {
+      "goal-achievement-helped": {
+        "maxLength": "How achieving this goal has helped must be 4,000 characters or less"
+      }
+    },
+    "confirmGoalAchievedButton": "Confirm",
+    "doNotMarkAsAchievedLink": "Do not mark as achieved"
+  }
+}

--- a/server/routes/reAddGoal/locale.json
+++ b/server/routes/reAddGoal/locale.json
@@ -16,7 +16,7 @@
         "maxLength": "The reason for adding this goal back into the plan must be 4,000 characters or less"
       },
       "start-working-goal-radio": {
-        "isNotEmpty": "Select yes if they can start working on this goal now"
+        "isNotEmpty": "We do not want to see this message"
       },
       "date-selection-radio": {
         "isNotEmpty": "Select when they should aim to achieve this goal"

--- a/server/routes/reAddGoal/locale.json
+++ b/server/routes/reAddGoal/locale.json
@@ -7,15 +7,26 @@
     "mainHeading": {
       "title": "Confirm you want to add this goal back into {{ subject.possessiveName }} plan"
     },
-    "notes": {
-      "label": "How has achieving this goal helped {{ subject.givenName }}? (optional)"
+    "reason": {
+      "label": "Why do you want to add this goal back into {{ subject.possessiveName }} plan?"
     },
     "errors": {
-      "goal-achievement-helped": {
-        "maxLength": "How achieving this goal has helped must be 4,000 characters or less"
+      "re-add-goal-reason": {
+        "isNotEmpty": "Enter why you want to add this goal back into their plan",
+        "maxLength": "The reason for adding this goal back into the plan must be 4,000 characters or less"
+      },
+      "start-working-goal-radio": {
+        "isNotEmpty": "Select yes if they can start working on this goal now"
+      },
+      "date-selection-radio": {
+        "isNotEmpty": "Select when they should aim to achieve this goal"
+      },
+      "date-selection-custom": {
+        "isNotEmpty": "Select a date",
+        "GoalDateMustBeTodayOrFuture": "Date must be today or in the future"
       }
     },
     "confirmGoalAchievedButton": "Confirm",
-    "doNotMarkAsAchievedLink": "Do not mark as achieved"
+    "doNotMarkAsAchievedLink": "Do not add goal back into plan"
   }
 }

--- a/server/routes/reAddGoal/locale.json
+++ b/server/routes/reAddGoal/locale.json
@@ -16,7 +16,7 @@
         "maxLength": "The reason for adding this goal back into the plan must be 4,000 characters or less"
       },
       "start-working-goal-radio": {
-        "isNotEmpty": "We do not want to see this message"
+        "isNotEmpty": "Select yes if they can start working on this goal now"
       },
       "date-selection-radio": {
         "isNotEmpty": "Select when they should aim to achieve this goal"

--- a/server/routes/reAddGoal/models/ReAddGoalPostModel.ts
+++ b/server/routes/reAddGoal/models/ReAddGoalPostModel.ts
@@ -1,6 +1,4 @@
-import { IsNotEmpty, MaxLength, Validate, ValidateIf } from 'class-validator'
-import { Expose } from 'class-transformer'
-import GoalDateMustBeTodayOrFuture from '../../validators/GoalDateMustBeTodayOrFuture'
+import { IsNotEmpty, MaxLength } from 'class-validator'
 
 export default class ReAddGoalPostModel {
   @IsNotEmpty()
@@ -10,13 +8,13 @@ export default class ReAddGoalPostModel {
   @IsNotEmpty()
   'start-working-goal-radio': string
 
-  @ValidateIf(o => o['start-working-goal-radio'] === 'yes')
-  @IsNotEmpty()
-  'date-selection-radio': string
-
-  @ValidateIf(o => o['date-selection-radio'] === 'custom' && o['start-working-goal-radio'] === 'yes')
-  @IsNotEmpty()
-  @Validate(GoalDateMustBeTodayOrFuture, { message: 'Date must be today or in the future' })
-  @Expose()
-  'date-selection-custom': string
+  // @ValidateIf(o => o['start-working-goal-radio'] === 'yes')
+  // @IsNotEmpty()
+  // 'date-selection-radio': string
+  //
+  // @ValidateIf(o => o['date-selection-radio'] === 'custom' && o['start-working-goal-radio'] === 'yes')
+  // @IsNotEmpty()
+  // @Validate(GoalDateMustBeTodayOrFuture, { message: 'Date must be today or in the future' })
+  // @Expose()
+  // 'date-selection-custom': string
 }

--- a/server/routes/reAddGoal/models/ReAddGoalPostModel.ts
+++ b/server/routes/reAddGoal/models/ReAddGoalPostModel.ts
@@ -1,4 +1,6 @@
-import { IsNotEmpty, MaxLength } from 'class-validator'
+import { IsNotEmpty, MaxLength, Validate, ValidateIf } from 'class-validator'
+import { Expose } from 'class-transformer'
+import GoalDateMustBeTodayOrFuture from '../../validators/GoalDateMustBeTodayOrFuture'
 
 export default class ReAddGoalPostModel {
   @IsNotEmpty()
@@ -8,13 +10,13 @@ export default class ReAddGoalPostModel {
   @IsNotEmpty()
   'start-working-goal-radio': string
 
-  // @ValidateIf(o => o['start-working-goal-radio'] === 'yes')
-  // @IsNotEmpty()
-  // 'date-selection-radio': string
-  //
-  // @ValidateIf(o => o['date-selection-radio'] === 'custom' && o['start-working-goal-radio'] === 'yes')
-  // @IsNotEmpty()
-  // @Validate(GoalDateMustBeTodayOrFuture, { message: 'Date must be today or in the future' })
-  // @Expose()
-  // 'date-selection-custom': string
+  @ValidateIf(o => o['start-working-goal-radio'] === 'yes')
+  @IsNotEmpty()
+  'date-selection-radio': string
+
+  @ValidateIf(o => o['date-selection-radio'] === 'custom' && o['start-working-goal-radio'] === 'yes')
+  @IsNotEmpty()
+  @Validate(GoalDateMustBeTodayOrFuture, { message: 'Date must be today or in the future' })
+  @Expose()
+  'date-selection-custom': string
 }

--- a/server/routes/reAddGoal/models/ReAddGoalPostModel.ts
+++ b/server/routes/reAddGoal/models/ReAddGoalPostModel.ts
@@ -1,0 +1,6 @@
+import { MaxLength } from 'class-validator'
+
+export default class ReAddGoalPostModel {
+  @MaxLength(4000)
+  'goal-achievement-helped': string
+}

--- a/server/routes/reAddGoal/models/ReAddGoalPostModel.ts
+++ b/server/routes/reAddGoal/models/ReAddGoalPostModel.ts
@@ -1,6 +1,22 @@
-import { MaxLength } from 'class-validator'
+import { IsNotEmpty, MaxLength, Validate, ValidateIf } from 'class-validator'
+import { Expose } from 'class-transformer'
+import GoalDateMustBeTodayOrFuture from '../../validators/GoalDateMustBeTodayOrFuture'
 
 export default class ReAddGoalPostModel {
+  @IsNotEmpty()
   @MaxLength(4000)
-  'goal-achievement-helped': string
+  're-add-goal-reason': string
+
+  @IsNotEmpty()
+  'start-working-goal-radio': string
+
+  @ValidateIf(o => o['start-working-goal-radio'] === 'yes')
+  @IsNotEmpty()
+  'date-selection-radio': string
+
+  @ValidateIf(o => o['date-selection-radio'] === 'custom' && o['start-working-goal-radio'] === 'yes')
+  @IsNotEmpty()
+  @Validate(GoalDateMustBeTodayOrFuture, { message: 'Date must be today or in the future' })
+  @Expose()
+  'date-selection-custom': string
 }

--- a/server/routes/reAddGoal/routes.ts
+++ b/server/routes/reAddGoal/routes.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express'
+import URLs from '../URLs'
+import ReAddGoalController from './ReAddGoalController'
+
+export default function setupReAddGoalRoutes(router: Router) {
+  const controller = new ReAddGoalController()
+
+  router.get(URLs.RE_ADD_GOAL, controller.get)
+  router.post(URLs.RE_ADD_GOAL, controller.post)
+}

--- a/server/routes/removeGoal/RemoveGoalController.test.ts
+++ b/server/routes/removeGoal/RemoveGoalController.test.ts
@@ -41,7 +41,7 @@ jest.mock('../../services/sentence-plan/goalService', () => {
     deleteGoal: jest.fn().mockReturnValue({ status: 204 }),
     removeGoal: jest.fn().mockReturnValue(testGoal),
     getGoal: jest.fn().mockReturnValue(testGoal),
-    updateGoal: jest.fn().mockReturnValue(testGoal),
+    updateGoalStatus: jest.fn().mockReturnValue(testGoal),
   }))
 })
 
@@ -135,7 +135,7 @@ describe('Test Removing Goal', () => {
 
       await runMiddlewareChain(controller.post, req, res, next)
 
-      expect(req.services.goalService.updateGoal).toHaveBeenCalled()
+      expect(req.services.goalService.updateGoalStatus).toHaveBeenCalled()
       expect(res.redirect).toHaveBeenCalledWith(`${URLs.PLAN_OVERVIEW}?type=removed&status=removed`)
     })
 
@@ -144,7 +144,7 @@ describe('Test Removing Goal', () => {
 
       await runMiddlewareChain(controller.post, req, res, next)
 
-      expect(req.services.goalService.updateGoal).not.toHaveBeenCalled()
+      expect(req.services.goalService.updateGoalStatus).not.toHaveBeenCalled()
       expect(res.render).toHaveBeenCalled()
     })
   })

--- a/server/routes/removeGoal/RemoveGoalController.ts
+++ b/server/routes/removeGoal/RemoveGoalController.ts
@@ -75,7 +75,7 @@ export default class RemoveGoalController {
         }
 
         try {
-          await req.services.goalService.updateGoal(goalData, goalUuid)
+          await req.services.goalService.updateGoalStatus(goalData, goalUuid)
           return res.redirect(`${URLs.PLAN_OVERVIEW}?type=removed&status=removed`)
         } catch (e) {
           return next(e)

--- a/server/routes/update-goal/UpdateGoalController.test.ts
+++ b/server/routes/update-goal/UpdateGoalController.test.ts
@@ -27,7 +27,7 @@ jest.mock('../../services/sentence-plan/referentialDataService', () => {
 jest.mock('../../services/sentence-plan/goalService', () => {
   return jest.fn().mockImplementation(() => ({
     getGoal: jest.fn().mockResolvedValue(testGoal),
-    updateGoal: jest.fn().mockResolvedValue(testGoal),
+    updateGoalStatus: jest.fn().mockResolvedValue(testGoal),
   }))
 })
 

--- a/server/routes/viewGoalDetails/ViewGoalDetailsController.test.ts
+++ b/server/routes/viewGoalDetails/ViewGoalDetailsController.test.ts
@@ -61,7 +61,6 @@ describe('ViewGoalDetailsController', () => {
   })
 
   describe('get', () => {
-    // todo: change the array so it passes in the redirect location as well as the status and then assert that
     test.each([
       [GoalStatus.ACHIEVED, URLs.PLAN_OVERVIEW],
       [GoalStatus.REMOVED, `/view-removed-goal/${testGoal.uuid}`],

--- a/server/routes/viewGoalDetails/ViewGoalDetailsController.test.ts
+++ b/server/routes/viewGoalDetails/ViewGoalDetailsController.test.ts
@@ -7,18 +7,15 @@ import { testGoal } from '../../testutils/data/goalData'
 import URLs from '../URLs'
 import { Goal, GoalStatus } from '../../@types/GoalType'
 import runMiddlewareChain from '../../testutils/runMiddlewareChain'
+import HandoverContextService from '../../services/handover/handoverContextService'
+import PlanService from '../../services/sentence-plan/planService'
+import SessionService from '../../services/sessionService'
 
 jest.mock('../../middleware/authorisationMiddleware', () => ({
   requireAccessMode: jest.fn(() => (req: Request, res: Response, next: NextFunction) => {
     return next()
   }),
 }))
-
-jest.mock('../../services/sessionService', () => {
-  return jest.fn().mockImplementation(() => ({
-    getReturnLink: jest.fn(),
-  }))
-})
 
 jest.mock('../../services/sentence-plan/goalService', () => {
   return jest.fn().mockImplementation(() => ({
@@ -32,6 +29,10 @@ describe('ViewGoalDetailsController', () => {
   let req: Request
   let res: Response
   let next: NextFunction
+
+  let handoverContextServiceMock: jest.Mocked<HandoverContextService>
+  let planServiceMock: jest.Mocked<PlanService>
+  let sessionService: SessionService
 
   const viewData = {
     locale: locale.en,
@@ -49,29 +50,38 @@ describe('ViewGoalDetailsController', () => {
     res = mockRes()
     next = jest.fn()
 
+    handoverContextServiceMock = new HandoverContextService(null) as jest.Mocked<HandoverContextService>
+    planServiceMock = new PlanService(null) as jest.Mocked<PlanService>
+    sessionService = new SessionService(req, handoverContextServiceMock, planServiceMock)
+    sessionService.setReturnLink(URLs.PLAN_OVERVIEW)
+
+    req.services.sessionService = sessionService
+
     controller = new ViewGoalDetailsController()
   })
 
   describe('get', () => {
-    test.each([[GoalStatus.ACHIEVED], [GoalStatus.REMOVED]])(
-      'should render without validation errors for %s',
-      async status => {
-        const goal: Goal = { ...testGoal, status }
-        req.services.goalService.getGoal = jest.fn().mockResolvedValue(goal)
+    // todo: change the array so it passes in the redirect location as well as the status and then assert that
+    test.each([
+      [GoalStatus.ACHIEVED, URLs.PLAN_OVERVIEW],
+      [GoalStatus.REMOVED, `/view-removed-goal/${testGoal.uuid}`],
+    ])('should render without validation errors for %s', async (status, returnLink) => {
+      const goal: Goal = { ...testGoal, status }
+      req.services.goalService.getGoal = jest.fn().mockResolvedValue(goal)
 
-        const viewDataPermittedStatus = {
-          ...viewData,
-          data: {
-            goal,
-            returnLink: URLs.PLAN_OVERVIEW,
-          },
-        }
+      const viewDataPermittedStatus = {
+        ...viewData,
+        data: {
+          goal,
+          returnLink: URLs.PLAN_OVERVIEW,
+        },
+      }
 
-        await runMiddlewareChain(controller.get, req, res, next)
+      await runMiddlewareChain(controller.get, req, res, next)
 
-        expect(res.render).toHaveBeenCalledWith('pages/view-goal-details', viewDataPermittedStatus)
-      },
-    )
+      expect(sessionService.getReturnLink()).toBe(returnLink)
+      expect(res.render).toHaveBeenCalledWith('pages/view-goal-details', viewDataPermittedStatus)
+    })
 
     it('should not render when Goal is not Achieved or Removed', async () => {
       await runMiddlewareChain(controller.get, req, res, next)

--- a/server/routes/viewGoalDetails/ViewGoalDetailsController.ts
+++ b/server/routes/viewGoalDetails/ViewGoalDetailsController.ts
@@ -21,6 +21,10 @@ export default class ViewGoalDetailsController {
         return next()
       }
 
+      if (goal.status === GoalStatus.REMOVED) {
+        req.services.sessionService.setReturnLink(`/view-removed-goal/${goal.uuid}`)
+      }
+
       return res.render('pages/view-goal-details', {
         locale: locale.en,
         data: {

--- a/server/services/sentence-plan/goalService.ts
+++ b/server/services/sentence-plan/goalService.ts
@@ -17,6 +17,7 @@ export default class GoalService {
     return restClient.put<Goal>({ path: `/goals/${goalUuid}`, data: goal })
   }
 
+  // rename this to updateGoalStatus
   async updateGoal(goal: Partial<NewGoal>, goalUuid: string) {
     const restClient = await this.sentencePlanApiClient.restClient('Update goal data')
     return restClient.patch<Goal>({ path: `/goals/${goalUuid}`, data: goal })

--- a/server/services/sentence-plan/goalService.ts
+++ b/server/services/sentence-plan/goalService.ts
@@ -17,9 +17,8 @@ export default class GoalService {
     return restClient.put<Goal>({ path: `/goals/${goalUuid}`, data: goal })
   }
 
-  // rename this to updateGoalStatus
-  async updateGoal(goal: Partial<NewGoal>, goalUuid: string) {
-    const restClient = await this.sentencePlanApiClient.restClient('Update goal data')
+  async updateGoalStatus(goal: Partial<NewGoal>, goalUuid: string) {
+    const restClient = await this.sentencePlanApiClient.restClient('Update goal status')
     return restClient.patch<Goal>({ path: `/goals/${goalUuid}`, data: goal })
   }
 

--- a/server/utils/commonLocale.json
+++ b/server/utils/commonLocale.json
@@ -55,6 +55,40 @@
         "relatedAreasOfNeed": "Also relates to: {{ relatedAreasOfNeed }}"
       }
     },
+    "goalEditing": {
+      "startWorking": {
+        "label": "Can {{ subject.givenName }} start working on this goal now?",
+        "options": {
+          "yes": "Yes",
+          "no": "No, it is a future goal"
+        }
+      },
+      "dateSelection": {
+        "label": "When should {{ subject.givenName }} aim to achieve this goal?",
+        "options": {
+          "threeMonths": "In 3 months ({{ dateOptions.threeMonths }})",
+          "sixMonths": "In 6 months ({{ dateOptions.sixMonths }})",
+          "twelveMonths": "In 12 months ({{ dateOptions.twelveMonths }})",
+          "custom": "Set another date"
+        }
+      },
+      "datePicker": {
+        "label": "Select a date",
+        "hint": "For example, 31/3/2023."
+      },
+      "errors": {
+        "start-working-goal-radio": {
+          "isNotEmpty": "Select yes if they can start working on this goal now"
+        },
+        "date-selection-radio": {
+          "isNotEmpty": "Select when they should aim to achieve this goal"
+        },
+        "date-selection-custom": {
+          "isNotEmpty": "Select a date",
+          "GoalDateMustBeTodayOrFuture": "Date must be today or in the future"
+        }
+      }
+    },
     "noteList": {
       "viewAllNotes": "View all notes",
       "noGoalNotes": "There are no notes on this goal yet.",

--- a/server/utils/commonLocale.json
+++ b/server/utils/commonLocale.json
@@ -78,7 +78,7 @@
       },
       "errors": {
         "start-working-goal-radio": {
-          "isNotEmpty": "Select yes if they can start working on this goal now"
+          "isNotEmpty": "This is the error message that should appear"
         },
         "date-selection-radio": {
           "isNotEmpty": "Select when they should aim to achieve this goal"

--- a/server/utils/commonLocale.json
+++ b/server/utils/commonLocale.json
@@ -78,7 +78,7 @@
       },
       "errors": {
         "start-working-goal-radio": {
-          "isNotEmpty": "This is the error message that should appear"
+          "isNotEmpty": "Select yes if they can start working on this goal now"
         },
         "date-selection-radio": {
           "isNotEmpty": "Select when they should aim to achieve this goal"

--- a/server/utils/commonLocale.json
+++ b/server/utils/commonLocale.json
@@ -79,7 +79,7 @@
       },
       "errors": {
         "start-working-goal-radio": {
-          "isNotEmpty": "Select yes if they can start working on this goal now"
+          "isNotEmpty": "This is the error message that should appear"
         },
         "date-selection-radio": {
           "isNotEmpty": "Select when they should aim to achieve this goal"

--- a/server/utils/commonLocale.json
+++ b/server/utils/commonLocale.json
@@ -79,7 +79,7 @@
       },
       "errors": {
         "start-working-goal-radio": {
-          "isNotEmpty": "This is the error message that should appear"
+          "isNotEmpty": "Select yes if they can start working on this goal now"
         },
         "date-selection-radio": {
           "isNotEmpty": "Select when they should aim to achieve this goal"

--- a/server/utils/commonLocale.json
+++ b/server/utils/commonLocale.json
@@ -56,6 +56,40 @@
         "relatedAreasOfNeed": "Also relates to: {{ relatedAreasOfNeed }}"
       }
     },
+    "goalEditing": {
+      "startWorking": {
+        "label": "Can {{ subject.givenName }} start working on this goal now?",
+        "options": {
+          "yes": "Yes",
+          "no": "No, it is a future goal"
+        }
+      },
+      "dateSelection": {
+        "label": "When should {{ subject.givenName }} aim to achieve this goal?",
+        "options": {
+          "threeMonths": "In 3 months ({{ dateOptions.threeMonths }})",
+          "sixMonths": "In 6 months ({{ dateOptions.sixMonths }})",
+          "twelveMonths": "In 12 months ({{ dateOptions.twelveMonths }})",
+          "custom": "Set another date"
+        }
+      },
+      "datePicker": {
+        "label": "Select a date",
+        "hint": "For example, 31/3/2023."
+      },
+      "errors": {
+        "start-working-goal-radio": {
+          "isNotEmpty": "Select yes if they can start working on this goal now"
+        },
+        "date-selection-radio": {
+          "isNotEmpty": "Select when they should aim to achieve this goal"
+        },
+        "date-selection-custom": {
+          "isNotEmpty": "Select a date",
+          "GoalDateMustBeTodayOrFuture": "Date must be today or in the future"
+        }
+      }
+    },
     "noteList": {
       "viewAllNotes": "View all notes",
       "noGoalNotes": "There are no notes on this goal yet.",

--- a/server/utils/commonLocale.json
+++ b/server/utils/commonLocale.json
@@ -76,18 +76,6 @@
       "datePicker": {
         "label": "Select a date",
         "hint": "For example, 31/3/2023."
-      },
-      "errors": {
-        "start-working-goal-radio": {
-          "isNotEmpty": "Select yes if they can start working on this goal now"
-        },
-        "date-selection-radio": {
-          "isNotEmpty": "Select when they should aim to achieve this goal"
-        },
-        "date-selection-custom": {
-          "isNotEmpty": "Select a date",
-          "GoalDateMustBeTodayOrFuture": "Date must be today or in the future"
-        }
       }
     },
     "noteList": {

--- a/server/utils/goalTargetDateUtils.ts
+++ b/server/utils/goalTargetDateUtils.ts
@@ -1,5 +1,18 @@
 import { dateToISOFormat } from './utils'
 
+export function getDateOptions(): Date[] {
+  const today = new Date()
+  return getAchieveDateOptions(today)
+}
+
+function getAchieveDateOptions(date: Date, dateOptionsInMonths = [3, 6, 12]) {
+  return dateOptionsInMonths.map(option => {
+    const achieveDate = new Date(date)
+    achieveDate.setMonth(date.getMonth() + option)
+    return achieveDate
+  })
+}
+
 export function getGoalTargetDate(
   canStartWorkingOnGoalNow: string,
   selectedDateOption: string,

--- a/server/utils/goalTargetDateUtils.ts
+++ b/server/utils/goalTargetDateUtils.ts
@@ -1,0 +1,15 @@
+import { dateToISOFormat } from './utils'
+
+export function getGoalTargetDate(
+  canStartWorkingOnGoalNow: string,
+  selectedDateOption: string,
+  customDate: string,
+): string {
+  if (canStartWorkingOnGoalNow === 'yes') {
+    if (selectedDateOption === 'custom') {
+      return dateToISOFormat(customDate)
+    }
+    return selectedDateOption
+  }
+  return null
+}

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,6 +1,4 @@
 import { DateTime } from 'luxon'
-// eslint-disable-next-line import/no-extraneous-dependencies
-import camelCase from 'camelcase'
 import { Person } from '../@types/Person'
 import { NewStep, StepStatus } from '../@types/StepType'
 import { GoalStatus } from '../@types/GoalType'
@@ -43,13 +41,6 @@ export function formatDate(date: string): string {
     month: 'long',
     year: 'numeric',
   })
-}
-
-export const motivationText = (optionResult?: string): string => {
-  if (optionResult === undefined || optionResult === null) {
-    return undefined
-  }
-  return camelCase(optionResult)
 }
 
 export const dateWithYear = (datetimeString: string): string | null => {

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -88,14 +88,6 @@ export function moveGoal(goals: Array<any>, gUuid: string, operation: string) {
   return orderedGoals.map(({ uuid: goalUuid, goalOrder }) => ({ goalUuid, goalOrder }))
 }
 
-export function getAchieveDateOptions(date: Date, dateOptionsInMonths = [3, 6, 12]) {
-  return dateOptionsInMonths.map(option => {
-    const achieveDate = new Date(date)
-    achieveDate.setMonth(date.getMonth() + option)
-    return achieveDate
-  })
-}
-
 export function mergeDeep(...objects: Record<string, any>[]): Record<string, any> {
   const isObject = (obj: any) => obj && typeof obj === 'object'
 

--- a/server/views/pages/change-goal.njk
+++ b/server/views/pages/change-goal.njk
@@ -119,10 +119,10 @@
                         errorMessage: getFormattedError(errors, locale, 'date-selection-custom'),
                         classes: "govuk-input--width-10",
                         hint: {
-                            text: locale.datePicker.hint
+                            text: locale.common.goalEditing.datePicker.hint
                         },
                         label: {
-                            text: locale.datePicker.label,
+                            text: locale.common.goalEditing.datePicker.label,
                             classes: "govuk-fieldset__legend--s"
                         },
                         value: data.form['date-selection-custom'],
@@ -135,35 +135,35 @@
                         name: "date-selection-radio",
                         fieldset: {
                             legend: {
-                                text: locale.dateSelection.label,
+                                text: locale.common.goalEditing.dateSelection.label,
                                 isPageHeading: false,
                                 classes: "govuk-fieldset__legend--m"
                             }
                         },
                         hint: {
-                            text: locale.dateSelection.hint
+                            text: locale.common.goalEditing.dateSelection.hint
                         },
                         errorMessage: getFormattedError(errors, locale, 'date-selection-radio'),
                         value: data.form['date-selection-radio'],
                         items: [
                             {
                                 value: data.dateOptions[0] | formatISODate,
-                                text: locale.dateSelection.options.threeMonths
+                                text: locale.common.goalEditing.dateSelection.options.threeMonths
                             },
                             {
                                 value: data.dateOptions[1] | formatISODate,
-                                text: locale.dateSelection.options.sixMonths
+                                text: locale.common.goalEditing.dateSelection.options.sixMonths
                             },
                             {
                                 value: data.dateOptions[2] | formatISODate,
-                                text: locale.dateSelection.options.twelveMonths
+                                text: locale.common.goalEditing.dateSelection.options.twelveMonths
                             },
                             {
                                 divider: locale.common.radio.divider
                             },
                             {
                                 value: "custom",
-                                text: locale.dateSelection.options.custom,
+                                text: locale.common.goalEditing.dateSelection.options.custom,
                                 conditional: {
                                 html: customDateHtml
                             }
@@ -176,7 +176,7 @@
                     name: "start-working-goal-radio",
                     fieldset: {
                         legend: {
-                            text: locale.startWorking.label,
+                            text: locale.common.goalEditing.startWorking.label,
                             isPageHeading: false,
                             classes: "govuk-fieldset__legend--m"
                         }
@@ -184,7 +184,7 @@
                     errorMessage: getFormattedError(errors, locale, 'start-working-goal-radio'),
                     items: [
                         {
-                            text: locale.startWorking.options.yes,
+                            text: locale.common.goalEditing.startWorking.options.yes,
                             value: "yes",
                             checked: data.form['start-working-goal-radio'] == 'yes',
                             conditional: {
@@ -192,7 +192,7 @@
                             }
                         },
                         {
-                            text: locale.startWorking.options.no,
+                            text: locale.common.goalEditing.startWorking.options.no,
                             value: "no",
                             checked: data.form['start-working-goal-radio'] == 'no'
                         }

--- a/server/views/pages/change-goal.njk
+++ b/server/views/pages/change-goal.njk
@@ -159,7 +159,7 @@
                                 text: locale.dateSelection.options.twelveMonths
                             },
                             {
-                                divider: "or"
+                                divider: locale.common.radio.divider
                             },
                             {
                                 value: "custom",

--- a/server/views/pages/confirm-re-add-goal.njk
+++ b/server/views/pages/confirm-re-add-goal.njk
@@ -1,8 +1,20 @@
 {% extends "../partials/layout.njk" %}
-{% from "../components/summary-card/goal-summary-card.njk" import goalSummaryCard %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "moj/components/date-picker/macro.njk" import mojDatePicker %}
+{% from "../components/summary-card/goal-summary-card.njk" import goalSummaryCard %}
 {% from "../components/error-summary/error-summary.njk" import errorSummary %}
+
+{% set locale = interpolate(locale, {
+  dateOptions: {
+    threeMonths: data.dateOptions[0] | formatSimpleDate,
+    sixMonths: data.dateOptions[1] | formatSimpleDate,
+    twelveMonths: data.dateOptions[2] | formatSimpleDate
+  }
+}) %}
 
 {% block pageTitle %}
     {% if not errors %}
@@ -30,29 +42,117 @@
             locale: locale
         }) }}
 
-        <form id="achieve-goal-form" method="POST">
-            <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-            <input type="hidden" name="uuid" value="{{ data.goal.uuid }}">
-            {{ govukTextarea({
-                name: "goal-achievement-helped",
-                id: "goal-achievement-helped",
-                classes: "govuk-!-width-two-thirds",
-                rows: 3,
-                label: {
-                    text: locale.notes.label,
-                    classes: "govuk-label--m"
-                },
-                value: data.form['goal-achievement-helped'],
-                errorMessage: getFormattedError(errors, locale, 'goal-achievement-helped')
-            }) }}
-            <div class="govuk-button-group">
-                {{ govukButton({
-                    text: locale.confirmGoalAchievedButton,
-                    name: "action",
-                    value: "confirm"
-                }) }}
-                <a class="govuk-link govuk-link--no-visited-state" href="/plan?type={{ data.type }}">{{ locale.doNotMarkAsAchievedLink }}</a>
-            </div>
+      <form id="re-add-goal-form" method="POST">
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+          <input type="hidden" name="uuid" value="{{ data.goal.uuid }}">
+
+        {{ govukTextarea({
+          name: "re-add-goal-reason",
+          id: "re-add-goal-reason",
+          classes: "govuk-!-width-two-thirds",
+          rows: 3,
+          label: {
+            text: locale.reason.label,
+            classes: "govuk-label--m"
+          },
+          value: data.form['re-add-goal-reason'],
+          errorMessage: getFormattedError(errors, locale, 're-add-goal-reason')
+        }) }}
+
+          {% set customDateHtml %}
+              {{ mojDatePicker({
+                  id: "date-selection-custom",
+                  name: "date-selection-custom",
+                  errorMessage: getFormattedError(errors, locale, 'date-selection-custom'),
+                  classes: "govuk-input--width-10",
+                  hint: {
+                      text: locale.common.datePicker.hint
+                  },
+                  label: {
+                      text: locale.common.datePicker.label,
+                      classes: "govuk-fieldset__legend--s"
+                  },
+                  value: data.form['date-selection-custom'],
+                  minDate: data.minimumDatePickerDate
+              }) }}
+          {% endset -%}
+
+          {% set customDateRadioHtml %}
+              {{ govukRadios({
+                  name: "date-selection-radio",
+                  fieldset: {
+                      legend: {
+                          text: locale.common.dateSelection.label,
+                          classes: "govuk-fieldset__legend--m"
+                      }
+                  },
+                  hint: {
+                      text: locale.common.dateSelection.hint
+                  },
+                  errorMessage: getFormattedError(errors, locale, 'date-selection-radio'),
+                  value: data.form['date-selection-radio'],
+                  items: [
+                      {
+                          value: data.dateOptions[0] | formatISODate,
+                          text: locale.common.goalEditing.dateSelection.options.threeMonths
+                      },
+                      {
+                          value: data.dateOptions[1] | formatISODate,
+                          text: locale.common.goalEditing.dateSelection.options.sixMonths
+                      },
+                      {
+                          value: data.dateOptions[2] | formatISODate,
+                          text: locale.common.goalEditing.dateSelection.options.twelveMonths
+                      },
+                      {
+                          divider: locale.common.radio.divider
+                      },
+                      {
+                          value: "custom",
+                          text: locale.common.goalEditing.dateSelection.options.custom,
+                          conditional: {
+                          html: customDateHtml
+                      }
+                      }
+                  ]
+              }) }}
+          {% endset -%}
+
+          {{ govukRadios({
+            name: "start-working-goal-radio",
+            fieldset: {
+              legend: {
+                text: locale.common.goalEditing.startWorking.label,
+                classes: "govuk-fieldset__legend--m"
+              }
+            },
+            errorMessage: getFormattedError(errors, locale, 'start-working-goal-radio'),
+            items: [
+              {
+                text: locale.common.goalEditing.startWorking.options.yes,
+                value: "yes",
+                checked: data.form['start-working-goal-radio'] == 'yes',
+                conditional: {
+                html: customDateRadioHtml
+              }
+              },
+              {
+                text: locale.common.goalEditing.startWorking.options.no,
+                value: "no",
+                checked: data.form['start-working-goal-radio'] == 'no'
+              }
+            ]
+          }) }}
+
+          <div class="govuk-button-group">
+{#            todo: change button locale lookup name for confirm #}
+              {{ govukButton({
+                  text: locale.confirmGoalAchievedButton,
+                  name: "action",
+                  value: "confirm"
+              }) }}
+              <a class="govuk-link govuk-link--no-visited-state" href="/plan?type={{ data.type }}">{{ locale.doNotMarkAsAchievedLink }}</a>
+          </div>
         </form>
     </div>
 </div>

--- a/server/views/pages/confirm-re-add-goal.njk
+++ b/server/views/pages/confirm-re-add-goal.njk
@@ -59,64 +59,64 @@
           errorMessage: getFormattedError(errors, locale, 're-add-goal-reason')
         }) }}
 
-          {% set customDateHtml %}
-              {{ mojDatePicker({
-                  id: "date-selection-custom",
-                  name: "date-selection-custom",
-                  errorMessage: getFormattedError(errors, locale, 'date-selection-custom'),
-                  classes: "govuk-input--width-10",
-                  hint: {
-                      text: locale.common.datePicker.hint
-                  },
-                  label: {
-                      text: locale.common.datePicker.label,
-                      classes: "govuk-fieldset__legend--s"
-                  },
-                  value: data.form['date-selection-custom'],
-                  minDate: data.minimumDatePickerDate
-              }) }}
-          {% endset -%}
+{#          {% set customDateHtml %}#}
+{#              {{ mojDatePicker({#}
+{#                  id: "date-selection-custom",#}
+{#                  name: "date-selection-custom",#}
+{#                  errorMessage: getFormattedError(errors, locale, 'date-selection-custom'),#}
+{#                  classes: "govuk-input--width-10",#}
+{#                  hint: {#}
+{#                      text: locale.common.datePicker.hint#}
+{#                  },#}
+{#                  label: {#}
+{#                      text: locale.common.datePicker.label,#}
+{#                      classes: "govuk-fieldset__legend--s"#}
+{#                  },#}
+{#                  value: data.form['date-selection-custom'],#}
+{#                  minDate: data.minimumDatePickerDate#}
+{#              }) }}#}
+{#          {% endset -%}#}
 
-          {% set customDateRadioHtml %}
-              {{ govukRadios({
-                  name: "date-selection-radio",
-                  fieldset: {
-                      legend: {
-                          text: locale.common.dateSelection.label,
-                          classes: "govuk-fieldset__legend--m"
-                      }
-                  },
-                  hint: {
-                      text: locale.common.dateSelection.hint
-                  },
-                  errorMessage: getFormattedError(errors, locale, 'date-selection-radio'),
-                  value: data.form['date-selection-radio'],
-                  items: [
-                      {
-                          value: data.dateOptions[0] | formatISODate,
-                          text: locale.common.goalEditing.dateSelection.options.threeMonths
-                      },
-                      {
-                          value: data.dateOptions[1] | formatISODate,
-                          text: locale.common.goalEditing.dateSelection.options.sixMonths
-                      },
-                      {
-                          value: data.dateOptions[2] | formatISODate,
-                          text: locale.common.goalEditing.dateSelection.options.twelveMonths
-                      },
-                      {
-                          divider: locale.common.radio.divider
-                      },
-                      {
-                          value: "custom",
-                          text: locale.common.goalEditing.dateSelection.options.custom,
-                          conditional: {
-                          html: customDateHtml
-                      }
-                      }
-                  ]
-              }) }}
-          {% endset -%}
+{#          {% set customDateRadioHtml %}#}
+{#              {{ govukRadios({#}
+{#                  name: "date-selection-radio",#}
+{#                  fieldset: {#}
+{#                      legend: {#}
+{#                          text: locale.common.dateSelection.label,#}
+{#                          classes: "govuk-fieldset__legend--m"#}
+{#                      }#}
+{#                  },#}
+{#                  hint: {#}
+{#                      text: locale.common.dateSelection.hint#}
+{#                  },#}
+{#                  errorMessage: getFormattedError(errors, locale, 'date-selection-radio'),#}
+{#                  value: data.form['date-selection-radio'],#}
+{#                  items: [#}
+{#                      {#}
+{#                          value: data.dateOptions[0] | formatISODate,#}
+{#                          text: locale.common.goalEditing.dateSelection.options.threeMonths#}
+{#                      },#}
+{#                      {#}
+{#                          value: data.dateOptions[1] | formatISODate,#}
+{#                          text: locale.common.goalEditing.dateSelection.options.sixMonths#}
+{#                      },#}
+{#                      {#}
+{#                          value: data.dateOptions[2] | formatISODate,#}
+{#                          text: locale.common.goalEditing.dateSelection.options.twelveMonths#}
+{#                      },#}
+{#                      {#}
+{#                          divider: locale.common.radio.divider#}
+{#                      },#}
+{#                      {#}
+{#                          value: "custom",#}
+{#                          text: locale.common.goalEditing.dateSelection.options.custom,#}
+{#                          conditional: {#}
+{#                          html: customDateHtml#}
+{#                      }#}
+{#                      }#}
+{#                  ]#}
+{#              }) }}#}
+{#          {% endset -%}#}
 
           {{ govukRadios({
             name: "start-working-goal-radio",
@@ -126,15 +126,12 @@
                 classes: "govuk-fieldset__legend--m"
               }
             },
-            errorMessage: getFormattedError(errors, locale, 'start-working-goal-radio'),
+            errorMessage: getFormattedError(errors, locale.common.goalEditing, 'start-working-goal-radio'),
             items: [
               {
                 text: locale.common.goalEditing.startWorking.options.yes,
                 value: "yes",
-                checked: data.form['start-working-goal-radio'] == 'yes',
-                conditional: {
-                html: customDateRadioHtml
-              }
+                checked: data.form['start-working-goal-radio'] == 'yes'
               },
               {
                 text: locale.common.goalEditing.startWorking.options.no,

--- a/server/views/pages/confirm-re-add-goal.njk
+++ b/server/views/pages/confirm-re-add-goal.njk
@@ -66,10 +66,10 @@
                   errorMessage: getFormattedError(errors, locale, 'date-selection-custom'),
                   classes: "govuk-input--width-10",
                   hint: {
-                      text: locale.common.datePicker.hint
+                      text: locale.common.goalEditing.datePicker.hint
                   },
                   label: {
-                      text: locale.common.datePicker.label,
+                      text: locale.common.goalEditing.datePicker.label,
                       classes: "govuk-fieldset__legend--s"
                   },
                   value: data.form['date-selection-custom'],

--- a/server/views/pages/confirm-re-add-goal.njk
+++ b/server/views/pages/confirm-re-add-goal.njk
@@ -1,0 +1,60 @@
+{% extends "../partials/layout.njk" %}
+{% from "../components/summary-card/goal-summary-card.njk" import goalSummaryCard %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "../components/error-summary/error-summary.njk" import errorSummary %}
+
+{% block pageTitle %}
+    {% if not errors %}
+        {{ locale.page.title }}
+    {% else %}
+        {{ locale.page.errorTitle }}
+    {% endif %}
+{% endblock %}
+
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+{{ super() }}
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <a href="{{ data.returnLink }}" class="govuk-back-link">{{ locale.common.backLink.text }}</a>
+        {{ errorSummary({
+            errors: errors,
+            locale: locale
+        }) }}
+        <h1 class="govuk-heading-l">{{ locale.mainHeading.title }}</h1>
+
+        {{ goalSummaryCard({
+            goal: data.goal,
+            locale: locale
+        }) }}
+
+        <form id="achieve-goal-form" method="POST">
+            <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+            <input type="hidden" name="uuid" value="{{ data.goal.uuid }}">
+            {{ govukTextarea({
+                name: "goal-achievement-helped",
+                id: "goal-achievement-helped",
+                classes: "govuk-!-width-two-thirds",
+                rows: 3,
+                label: {
+                    text: locale.notes.label,
+                    classes: "govuk-label--m"
+                },
+                value: data.form['goal-achievement-helped'],
+                errorMessage: getFormattedError(errors, locale, 'goal-achievement-helped')
+            }) }}
+            <div class="govuk-button-group">
+                {{ govukButton({
+                    text: locale.confirmGoalAchievedButton,
+                    name: "action",
+                    value: "confirm"
+                }) }}
+                <a class="govuk-link govuk-link--no-visited-state" href="/plan?type={{ data.type }}">{{ locale.doNotMarkAsAchievedLink }}</a>
+            </div>
+        </form>
+    </div>
+</div>
+
+{% endblock %}

--- a/server/views/pages/confirm-re-add-goal.njk
+++ b/server/views/pages/confirm-re-add-goal.njk
@@ -59,64 +59,64 @@
           errorMessage: getFormattedError(errors, locale, 're-add-goal-reason')
         }) }}
 
-{#          {% set customDateHtml %}#}
-{#              {{ mojDatePicker({#}
-{#                  id: "date-selection-custom",#}
-{#                  name: "date-selection-custom",#}
-{#                  errorMessage: getFormattedError(errors, locale, 'date-selection-custom'),#}
-{#                  classes: "govuk-input--width-10",#}
-{#                  hint: {#}
-{#                      text: locale.common.datePicker.hint#}
-{#                  },#}
-{#                  label: {#}
-{#                      text: locale.common.datePicker.label,#}
-{#                      classes: "govuk-fieldset__legend--s"#}
-{#                  },#}
-{#                  value: data.form['date-selection-custom'],#}
-{#                  minDate: data.minimumDatePickerDate#}
-{#              }) }}#}
-{#          {% endset -%}#}
+          {% set customDateHtml %}
+              {{ mojDatePicker({
+                  id: "date-selection-custom",
+                  name: "date-selection-custom",
+                  errorMessage: getFormattedError(errors, locale, 'date-selection-custom'),
+                  classes: "govuk-input--width-10",
+                  hint: {
+                      text: locale.common.datePicker.hint
+                  },
+                  label: {
+                      text: locale.common.datePicker.label,
+                      classes: "govuk-fieldset__legend--s"
+                  },
+                  value: data.form['date-selection-custom'],
+                  minDate: data.minimumDatePickerDate
+              }) }}
+          {% endset -%}
 
-{#          {% set customDateRadioHtml %}#}
-{#              {{ govukRadios({#}
-{#                  name: "date-selection-radio",#}
-{#                  fieldset: {#}
-{#                      legend: {#}
-{#                          text: locale.common.dateSelection.label,#}
-{#                          classes: "govuk-fieldset__legend--m"#}
-{#                      }#}
-{#                  },#}
-{#                  hint: {#}
-{#                      text: locale.common.dateSelection.hint#}
-{#                  },#}
-{#                  errorMessage: getFormattedError(errors, locale, 'date-selection-radio'),#}
-{#                  value: data.form['date-selection-radio'],#}
-{#                  items: [#}
-{#                      {#}
-{#                          value: data.dateOptions[0] | formatISODate,#}
-{#                          text: locale.common.goalEditing.dateSelection.options.threeMonths#}
-{#                      },#}
-{#                      {#}
-{#                          value: data.dateOptions[1] | formatISODate,#}
-{#                          text: locale.common.goalEditing.dateSelection.options.sixMonths#}
-{#                      },#}
-{#                      {#}
-{#                          value: data.dateOptions[2] | formatISODate,#}
-{#                          text: locale.common.goalEditing.dateSelection.options.twelveMonths#}
-{#                      },#}
-{#                      {#}
-{#                          divider: locale.common.radio.divider#}
-{#                      },#}
-{#                      {#}
-{#                          value: "custom",#}
-{#                          text: locale.common.goalEditing.dateSelection.options.custom,#}
-{#                          conditional: {#}
-{#                          html: customDateHtml#}
-{#                      }#}
-{#                      }#}
-{#                  ]#}
-{#              }) }}#}
-{#          {% endset -%}#}
+          {% set customDateRadioHtml %}
+              {{ govukRadios({
+                  name: "date-selection-radio",
+                  fieldset: {
+                      legend: {
+                          text: locale.common.dateSelection.label,
+                          classes: "govuk-fieldset__legend--m"
+                      }
+                  },
+                  hint: {
+                      text: locale.common.dateSelection.hint
+                  },
+                  errorMessage: getFormattedError(errors, locale, 'date-selection-radio'),
+                  value: data.form['date-selection-radio'],
+                  items: [
+                      {
+                          value: data.dateOptions[0] | formatISODate,
+                          text: locale.common.goalEditing.dateSelection.options.threeMonths
+                      },
+                      {
+                          value: data.dateOptions[1] | formatISODate,
+                          text: locale.common.goalEditing.dateSelection.options.sixMonths
+                      },
+                      {
+                          value: data.dateOptions[2] | formatISODate,
+                          text: locale.common.goalEditing.dateSelection.options.twelveMonths
+                      },
+                      {
+                          divider: locale.common.radio.divider
+                      },
+                      {
+                          value: "custom",
+                          text: locale.common.goalEditing.dateSelection.options.custom,
+                          conditional: {
+                          html: customDateHtml
+                      }
+                      }
+                  ]
+              }) }}
+          {% endset -%}
 
           {{ govukRadios({
             name: "start-working-goal-radio",
@@ -126,12 +126,15 @@
                 classes: "govuk-fieldset__legend--m"
               }
             },
-            errorMessage: getFormattedError(errors, locale.common.goalEditing, 'start-working-goal-radio'),
+            errorMessage: getFormattedError(errors, locale, 'start-working-goal-radio'),
             items: [
               {
                 text: locale.common.goalEditing.startWorking.options.yes,
                 value: "yes",
-                checked: data.form['start-working-goal-radio'] == 'yes'
+                checked: data.form['start-working-goal-radio'] == 'yes',
+                conditional: {
+                html: customDateRadioHtml
+              }
               },
               {
                 text: locale.common.goalEditing.startWorking.options.no,

--- a/server/views/pages/create-goal.njk
+++ b/server/views/pages/create-goal.njk
@@ -137,7 +137,8 @@
                       ]
                 }) }}
 
-                {% set customDateHtml %}
+              {# START HERE #}
+              {% set customDateHtml %}
                     {{ mojDatePicker({
                         id: "date-selection-custom",
                         name: "date-selection-custom",
@@ -235,6 +236,7 @@
                         classes: "govuk-button--secondary"
                     }) }}
                 </div>
+              {# END HERE, buttons need to be a parameter #}
             </form>
         </div>
     </div>

--- a/server/views/pages/create-goal.njk
+++ b/server/views/pages/create-goal.njk
@@ -145,10 +145,10 @@
                         errorMessage: getFormattedError(errors, locale, 'date-selection-custom'),
                         classes: "govuk-input--width-10",
                         hint: {
-                            text: locale.datePicker.hint
+                            text: locale.common.goalEditing.datePicker.hint
                         },
                         label: {
-                            text: locale.datePicker.label,
+                            text: locale.common.goalEditing.datePicker.label,
                             classes: "govuk-fieldset__legend--s"
                         },
                         value: data.form['date-selection-custom'],
@@ -161,34 +161,34 @@
                         name: "date-selection-radio",
                         fieldset: {
                             legend: {
-                                text: locale.dateSelection.label,
+                                text: locale.common.goalEditing.dateSelection.label,
                                 classes: "govuk-fieldset__legend--m"
                             }
                         },
                         hint: {
-                            text: locale.dateSelection.hint
+                            text: locale.common.goalEditing.dateSelection.hint
                         },
                         errorMessage: getFormattedError(errors, locale, 'date-selection-radio'),
                         value: data.form['date-selection-radio'],
                         items: [
                             {
                                 value: data.dateOptions[0] | formatISODate,
-                                text: locale.dateSelection.options.threeMonths
+                                text: locale.common.goalEditing.dateSelection.options.threeMonths
                             },
                             {
                                 value: data.dateOptions[1] | formatISODate,
-                                text: locale.dateSelection.options.sixMonths
+                                text: locale.common.goalEditing.dateSelection.options.sixMonths
                             },
                             {
                                 value: data.dateOptions[2] | formatISODate,
-                                text: locale.dateSelection.options.twelveMonths
+                                text: locale.common.goalEditing.dateSelection.options.twelveMonths
                             },
                             {
                                 divider: locale.common.radio.divider
                             },
                             {
                                 value: "custom",
-                                text: locale.dateSelection.options.custom,
+                                text: locale.common.goalEditing.dateSelection.options.custom,
                                 conditional: {
                                     html: customDateHtml
                                 }
@@ -201,14 +201,14 @@
                     name: "start-working-goal-radio",
                     fieldset: {
                         legend: {
-                            text: locale.startWorking.label,
+                            text: locale.common.goalEditing.startWorking.label,
                             classes: "govuk-fieldset__legend--m"
                         }
                     },
                     errorMessage: getFormattedError(errors, locale, 'start-working-goal-radio'),
                     items: [
                         {
-                            text: locale.startWorking.options.yes,
+                            text: locale.common.goalEditing.startWorking.options.yes,
                             value: "yes",
                             checked: data.form['start-working-goal-radio'] == 'yes',
                             conditional: {
@@ -216,7 +216,7 @@
                             }
                         },
                         {
-                            text: locale.startWorking.options.no,
+                            text: locale.common.goalEditing.startWorking.options.no,
                             value: "no",
                             checked: data.form['start-working-goal-radio'] == 'no'
                         }

--- a/server/views/pages/plan-history.njk
+++ b/server/views/pages/plan-history.njk
@@ -72,6 +72,10 @@
                 <p class='goal-status'><strong>{{ locale.note.status.goal.removed }}</strong> {{ locale.who.practitionerOnly }}</p>
                 <p class='goal-title'><strong>{{ note.goalTitle }}</strong></p>
                 <p class='goal-note'>{{ note.note }}</p>
+              {% elseif note.noteType == 'READDED'%}
+                <p class='goal-status'><strong>{{ locale.note.status.goal.addedBackToPlan }}</strong> {{ locale.who.practitionerOnly }}</p>
+                <p class='goal-title'><strong>{{ note.goalTitle }}</strong></p>
+                <p class='goal-note'>{{ note.note }}</p>
             {% elseif note.noteType == 'ACHIEVED'%}
                 <p class='goal-status'><strong>{{ locale.note.status.goal.achieved }}</strong> {{ locale.who.practitionerOnly }}</p>
                 <p class='goal-title'><strong>{{ note.goalTitle }}</strong></p>

--- a/server/views/pages/view-goal-details.njk
+++ b/server/views/pages/view-goal-details.njk
@@ -72,13 +72,12 @@
             }) }}
 
             {% if data.goal.status == 'REMOVED' %}
-{#               TODO:SP2-598#}
-{#                {{ govukButton(}#}
-{#                    text: locale.addToPlan,#}
-{#                    name: "action",#}
-{#                    value: "#",#}
-{#                    classes: "govuk-button--secondary"#}
-{#                }) }}#}
+                {{ govukButton({
+                    text: locale.addToPlan,
+                    name: "action",
+                    value: "#",
+                    classes: "govuk-button--secondary"
+                }) }}
             {% endif %}
 
         </div>

--- a/server/views/pages/view-goal-details.njk
+++ b/server/views/pages/view-goal-details.njk
@@ -74,9 +74,8 @@
             {% if data.goal.status == 'REMOVED' %}
                 {{ govukButton({
                     text: locale.addToPlan,
-                    name: "action",
-                    value: "#",
-                    classes: "govuk-button--secondary"
+                    href: '/confirm-add-goal/' + data.goal.uuid,
+                    classes: "govuk-button--secondary add-to-plan"
                 }) }}
             {% endif %}
 


### PR DESCRIPTION
This PR adds support for re-adding a goal back to a plan after it has been removed.

The end-to-end tests will fail until https://github.com/ministryofjustice/hmpps-sentence-plan/pull/164 is merged.

This also adds backend API support for agreeing a plan and removing a goal so that we don't have to go through those pages when they are secondary to the main purpose of the tests.

I also extracted some duplicated functionality from several controllers and put it in a new utils class used when setting goal target dates.