### PR TITLE
Back link selects correct tab based on goal type

### DIFF
--- a/integration_tests/e2e/update-goal.cy.ts
+++ b/integration_tests/e2e/update-goal.cy.ts
@@ -55,16 +55,14 @@ describe('Update goal', () => {
     it('Back link on a current goal returns to correct tab on plan overview', () => {
       cy.get<Goal>('@goalForNow').then(goal => {
         cy.visit(`/update-goal-steps/${goal.uuid}`)
-        cy.contains('a', 'Back').click()
-        cy.url().should('include', '/plan?type=current')
+        cy.contains('a', 'Back').should('have.attr', 'href', '/plan?type=current')
       })
     })
 
     it('Back link on a future goal returns to correct tab on plan overview', () => {
       cy.get<Goal>('@goalForFuture').then(goal => {
         cy.visit(`/update-goal-steps/${goal.uuid}`)
-        cy.contains('a', 'Back').click()
-        cy.url().should('include', '/plan?type=future')
+        cy.contains('a', 'Back').should('have.attr', 'href', '/plan?type=future')
       })
     })
 

--- a/integration_tests/e2e/update-goal.cy.ts
+++ b/integration_tests/e2e/update-goal.cy.ts
@@ -52,6 +52,22 @@ describe('Update goal', () => {
       })
     })
 
+    it('Back link on a current goal returns to correct tab on plan overview', () => {
+      cy.get<Goal>('@goalForNow').then(goal => {
+        cy.visit(`/update-goal-steps/${goal.uuid}`)
+        cy.contains('a', 'Back').click()
+        cy.url().should('include', '/plan?type=current')
+      })
+    })
+
+    it('Back link on a future goal returns to correct tab on plan overview', () => {
+      cy.get<Goal>('@goalForFuture').then(goal => {
+        cy.visit(`/update-goal-steps/${goal.uuid}`)
+        cy.contains('a', 'Back').click()
+        cy.url().should('include', '/plan?type=future')
+      })
+    })
+
     it('Should say no steps added', () => {
       cy.get<Goal>('@goalWithNoSteps').then(goal => {
         cy.visit(`/update-goal-steps/${goal.uuid}`)

--- a/server/routes/update-goal/UpdateGoalController.test.ts
+++ b/server/routes/update-goal/UpdateGoalController.test.ts
@@ -62,6 +62,7 @@ describe('UpdateGoalController', () => {
       mainAreaOfNeed: AreaOfNeed.find(x => x.name === testGoal.areaOfNeed.name),
       relatedAreasOfNeed: testGoal.relatedAreasOfNeed.map(x => x.name),
       returnLink: '/some-return-link',
+      goalType: 'current',
     },
     errors: {},
   }

--- a/server/routes/update-goal/UpdateGoalController.test.ts
+++ b/server/routes/update-goal/UpdateGoalController.test.ts
@@ -61,8 +61,7 @@ describe('UpdateGoalController', () => {
       popData: handoverData.subject,
       mainAreaOfNeed: AreaOfNeed.find(x => x.name === testGoal.areaOfNeed.name),
       relatedAreasOfNeed: testGoal.relatedAreasOfNeed.map(x => x.name),
-      returnLink: '/some-return-link',
-      goalType: 'current',
+      returnLink: '/plan?type=current',
     },
     errors: {},
   }

--- a/server/routes/update-goal/UpdateGoalController.ts
+++ b/server/routes/update-goal/UpdateGoalController.ts
@@ -30,7 +30,7 @@ export default class UpdateGoalController {
       const mainAreaOfNeed = sortedAreasOfNeed.find(areaOfNeed => areaOfNeed.name === goal.areaOfNeed.name)
       const relatedAreasOfNeed = goal.relatedAreasOfNeed.map(need => need.name)
 
-      const returnLink = req.services.sessionService.getReturnLink()
+      const returnLink = `/plan?type=${goalType}`
       req.services.sessionService.setReturnLink(`/update-goal-steps/${uuid}`)
 
       return res.render('pages/update-goal', {
@@ -42,7 +42,6 @@ export default class UpdateGoalController {
           mainAreaOfNeed,
           relatedAreasOfNeed,
           returnLink,
-          goalType,
         },
         errors,
       })

--- a/server/routes/update-goal/UpdateGoalController.ts
+++ b/server/routes/update-goal/UpdateGoalController.ts
@@ -25,6 +25,7 @@ export default class UpdateGoalController {
     try {
       const sortedAreasOfNeed = this.referentialDataService.getSortedAreasOfNeed()
       const goal = await req.services.goalService.getGoal(uuid)
+      const goalType: string = goalStatusToTabName(goal.status)
       const popData = req.services.sessionService.getSubjectDetails()
       const mainAreaOfNeed = sortedAreasOfNeed.find(areaOfNeed => areaOfNeed.name === goal.areaOfNeed.name)
       const relatedAreasOfNeed = goal.relatedAreasOfNeed.map(need => need.name)
@@ -41,6 +42,7 @@ export default class UpdateGoalController {
           mainAreaOfNeed,
           relatedAreasOfNeed,
           returnLink,
+          goalType,
         },
         errors,
       })

--- a/server/views/pages/update-goal.njk
+++ b/server/views/pages/update-goal.njk
@@ -53,7 +53,7 @@
 
 {% block content %}
     {{ super() }}
-    <a href="/plan" class="govuk-back-link">{{ locale.common.backLink.text }}</a>
+    <a href="/plan?type={{ data.goalType }}" class="govuk-back-link">{{ locale.common.backLink.text }}</a>
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">

--- a/server/views/pages/update-goal.njk
+++ b/server/views/pages/update-goal.njk
@@ -53,7 +53,7 @@
 
 {% block content %}
     {{ super() }}
-    <a href="/plan?type={{ data.goalType }}" class="govuk-back-link">{{ locale.common.backLink.text }}</a>
+    <a href="{{ data.returnLink }}" class="govuk-back-link">{{ locale.common.backLink.text }}</a>
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">


### PR DESCRIPTION
Following design review it was noticed that if a future goal was selected for update that the back link did not select the right link on the plan page.