### PR TITLE
SP2-1095 Remove Mark as Achieved from Plan page

### DIFF
--- a/integration_tests/e2e/achieve-goal.cy.ts
+++ b/integration_tests/e2e/achieve-goal.cy.ts
@@ -50,13 +50,13 @@ describe('Achieve goal', () => {
         })
 
         planOverview.agreePlan()
-        cy.get('a').contains('Mark as achieved').click()
       })
     })
 
-    it('Display agree plan page correctly on load', () => {
-      cy.get('h1').contains('has achieved this goal')
+    it('Displays agree plan page correctly on load', () => {
       cy.get<Goal>('@newGoal').then(goal => {
+        cy.visit(`/confirm-achieved-goal/${goal.uuid}`)
+        cy.get('h1').contains('has achieved this goal')
         cy.get('.govuk-summary-card__title').should('contain', goal.title)
       })
       cy.checkAccessibility()
@@ -72,7 +72,9 @@ describe('Achieve goal', () => {
         })
 
         planOverview.agreePlan()
-        cy.get('a').contains('Mark as achieved').click()
+        cy.get<Goal>('@newGoal').then(goal => {
+          cy.visit(`/confirm-achieved-goal/${goal.uuid}`)
+        })
       })
     })
 
@@ -125,7 +127,6 @@ describe('Achieve goal', () => {
     it('Cancel goal achieved and redirect successfully', () => {
       cy.get('a').contains('Do not mark as achieved').click()
       cy.url().should('include', 'plan?type=current')
-      planOverview.getSummaryCard(0).get('a').contains('Mark as achieved')
       cy.checkAccessibility()
     })
   })

--- a/integration_tests/e2e/achieve-goal.cy.ts
+++ b/integration_tests/e2e/achieve-goal.cy.ts
@@ -73,7 +73,8 @@ describe('Achieve goal', () => {
 
         planOverview.agreePlan()
         cy.get<Goal>('@newGoal').then(goal => {
-          cy.visit(`/confirm-achieved-goal/${goal.uuid}`)
+          cy.visit(`/update-goal-steps/${goal.uuid}`)
+          cy.get('button').contains('Mark as achieved').click()
         })
       })
     })
@@ -126,7 +127,7 @@ describe('Achieve goal', () => {
 
     it('Cancel goal achieved and redirect successfully', () => {
       cy.get('a').contains('Do not mark as achieved').click()
-      cy.url().should('include', 'plan?type=current')
+      cy.url().should('include', 'update-goal-steps/')
       cy.checkAccessibility()
     })
   })

--- a/integration_tests/e2e/plan-history.cy.ts
+++ b/integration_tests/e2e/plan-history.cy.ts
@@ -120,7 +120,8 @@ describe('Rendering READ_ONLY', () => {
       cy.get('.moj-primary-navigation__container').contains('Plan history').click()
       cy.get('.plan-status').contains('Plan agreed')
       cy.visit('/plan')
-      cy.contains('a', 'Mark as achieved').click()
+      cy.contains('a', 'Update').click()
+      cy.contains('button', 'Mark as achieved').click()
       cy.url().should('include', '/confirm-achieved-goal') // check url
       cy.get('textarea#goal-achievement-helped').type('Updated goal to achieved status')
       cy.get('.govuk-button').contains('Confirm').click()

--- a/integration_tests/e2e/plan-history.cy.ts
+++ b/integration_tests/e2e/plan-history.cy.ts
@@ -73,7 +73,8 @@ describe('Rendering READ_WRITE', () => {
     cy.get('.moj-primary-navigation__container').contains('Plan history').click()
     cy.get('.plan-status').contains('Plan agreed')
     cy.visit('/plan')
-    cy.contains('a', 'Mark as achieved').click()
+    cy.contains('a', 'Update').click()
+    cy.contains('button', 'Mark as achieved').click()
     cy.url().should('include', '/confirm-achieved-goal') // check url
     cy.get('textarea#goal-achievement-helped').type('Updated goal to achieved status')
     cy.get('.govuk-button').contains('Confirm').click()

--- a/server/routes/update-goal/UpdateGoalController.test.ts
+++ b/server/routes/update-goal/UpdateGoalController.test.ts
@@ -101,6 +101,22 @@ describe('UpdateGoalController', () => {
       expect(next).not.toHaveBeenCalled()
     })
 
+    it('should submit the updated fields and redirect to the mark as achieved page if mark as achieved clicked', async () => {
+      req.body = {
+        'step-status-1': StepStatus.IN_PROGRESS,
+        'step-uuid-1': testStep.uuid,
+        'more-detail': '',
+        action: 'mark-as-achieved',
+      }
+
+      await runMiddlewareChain(controller.post, req, res, next)
+
+      expect(req.services.stepService.saveAllSteps).toHaveBeenCalled()
+      expect(res.redirect).toHaveBeenCalledWith('/confirm-achieved-goal/a-un1qu3-t3st-Uu1d')
+      expect(res.render).not.toHaveBeenCalled()
+      expect(next).not.toHaveBeenCalled()
+    })
+
     it('should call next with an error if saveAllSteps fails', async () => {
       req.body = {
         'step-status-1': StepStatus.IN_PROGRESS,

--- a/server/routes/update-goal/UpdateGoalController.ts
+++ b/server/routes/update-goal/UpdateGoalController.ts
@@ -87,6 +87,10 @@ export default class UpdateGoalController {
 
       await this.updateSteps(req, goal, steps, note)
 
+      if (req.body.action === 'mark-as-achieved') {
+        return res.redirect(`${URLs.ACHIEVE_GOAL.replace(':uuid', uuid)}`)
+      }
+
       return res.redirect(`${URLs.PLAN_OVERVIEW}?type=${goalType}`)
 
       // TODO SP2-633

--- a/server/views/pages/confirm-achieved-goal.njk
+++ b/server/views/pages/confirm-achieved-goal.njk
@@ -51,7 +51,7 @@
                     name: "action",
                     value: "confirm"
                 }) }}
-                <a class="govuk-link govuk-link--no-visited-state" href="/plan?type={{ data.type }}">{{ locale.doNotMarkAsAchievedLink }}</a>
+                <a class="govuk-link govuk-link--no-visited-state" href="{{ data.returnLink }}">{{ locale.doNotMarkAsAchievedLink }}</a>
             </div>
         </form>
     </div>

--- a/server/views/pages/plan.njk
+++ b/server/views/pages/plan.njk
@@ -244,10 +244,6 @@
                                         text: locale.goalSummaryCard.actions.active.update
                                     },
                                     {
-                                        href: "/confirm-achieved-goal/" + goal.uuid + "?type=current",
-                                        text: locale.goalSummaryCard.actions.active.markAsAchieved
-                                    },
-                                    {
                                         href: "/remove-goal/" + goal.uuid + "?type=current",
                                         text: locale.goalSummaryCard.actions.active.removeGoal
                                     }

--- a/server/views/pages/update-goal.njk
+++ b/server/views/pages/update-goal.njk
@@ -156,9 +156,12 @@
                             }) }}
 
                             <div class="govuk-button-group">
-                                <button type="submit" class="govuk-button" data-module="govuk-button">
-                                    {{ locale.saveGoalAndSteps }}
-                                </button>
+                              <button type="submit" class="govuk-button" name="action" value="save" data-module="govuk-button">
+                                  {{ locale.saveGoalAndSteps }}
+                              </button>
+                              <button type="submit" class="govuk-button govuk-button--secondary" name="action" value="mark-as-achieved" data-module="govuk-button">
+                                {{ locale.markAsAchieved }}
+                              </button>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Removes the mark as achieved link from the actions on the summary card, moving it to the Update Goal page.