### PR TITLE
Updates following design review

### DIFF
--- a/integration_tests/e2e/re-add-goal.cy.ts
+++ b/integration_tests/e2e/re-add-goal.cy.ts
@@ -29,6 +29,13 @@ describe('Re-add a goal to a Plan after it has been removed', () => {
     cy.title().should('contain', 'Confirm you want to add this goal back into the plan')
   })
 
+  it('Back button on re-add goal confirmation links to goal details page', () => {
+    cy.visit(`/view-removed-goal/${removedGoal.uuid}`)
+    cy.get('a.add-to-plan').click()
+    cy.get('a').contains('Do not add goal back into plan').click()
+    cy.title().should('contain', 'View removed goal')
+  })
+
   it('Confirming re-add goal with target date loads plan overview on current goals tab', () => {
     cy.visit(`/view-removed-goal/${removedGoal.uuid}`)
     cy.get('a.add-to-plan').click()
@@ -59,6 +66,20 @@ describe('Re-add a goal to a Plan after it has been removed', () => {
 
     cy.visit('/plan-history')
     cy.get('.goal-status').first().should('contain.text', 'Goal added back into plan')
+    cy.get('.goal-note').first().should('contain.text', RE_ADD_REASON)
+  })
+
+  it('Re-adding a goal adds a note to the Goal notes', () => {
+    const RE_ADD_REASON = 'A reason for re-adding the goal'
+
+    cy.visit(`/view-removed-goal/${removedGoal.uuid}`)
+    cy.get('a.add-to-plan').click()
+    cy.get('#re-add-goal-reason').type(RE_ADD_REASON)
+    cy.get('input[name="start-working-goal-radio"][value="no"]').click()
+    cy.get('button').contains('Confirm').click()
+
+    cy.visit(`/update-goal-steps/${removedGoal.uuid}`)
+    cy.get('.goal-status').first().should('contain.text', 'Goal added back into plan on')
     cy.get('.goal-note').first().should('contain.text', RE_ADD_REASON)
   })
 })

--- a/server/routes/reAddGoal/ReAddGoalController.test.ts
+++ b/server/routes/reAddGoal/ReAddGoalController.test.ts
@@ -40,7 +40,7 @@ jest.mock('../../services/sentence-plan/planService', () => {
   }))
 })
 
-describe('AchieveGoalController', () => {
+describe('ReAddGoalController', () => {
   let controller: ReAddGoalController
   let req: Request
   let res: Response
@@ -54,6 +54,7 @@ describe('AchieveGoalController', () => {
       ],
       returnLink: '/some-return-link',
       goal: testGoal,
+      form: {},
     },
     errors: {},
     locale: locale.en,
@@ -84,7 +85,7 @@ describe('AchieveGoalController', () => {
 
     it('should render with validation errors', async () => {
       const errors = {
-        body: { 'goal-achievement-helped': { maxLength: true } },
+        body: { 're-add-goal-reason': { isNotEmpty: true } },
         params: {},
         query: {},
       }
@@ -101,7 +102,7 @@ describe('AchieveGoalController', () => {
   })
 
   describe('post', () => {
-    it('should mark goal as achieved with optional note details', async () => {
+    it('should mark goal as re-added with note details', async () => {
       req.params = {
         uuid: 'some-uuid',
       }

--- a/server/routes/reAddGoal/ReAddGoalController.ts
+++ b/server/routes/reAddGoal/ReAddGoalController.ts
@@ -23,6 +23,7 @@ export default class ReAddGoalController {
       const goal = await req.services.goalService.getGoal(uuid)
       const returnLink = req.services.sessionService.getReturnLink()
       const dateOptions = getDateOptions()
+      const form = errors ? req.body : null
 
       req.services.sessionService.setReturnLink(`/plan?type=removed`)
 
@@ -32,6 +33,7 @@ export default class ReAddGoalController {
           dateOptions,
           returnLink,
           goal,
+          form,
         },
         errors,
       })

--- a/server/routes/reAddGoal/locale.json
+++ b/server/routes/reAddGoal/locale.json
@@ -26,7 +26,7 @@
         "GoalDateMustBeTodayOrFuture": "Date must be today or in the future"
       }
     },
-    "confirmGoalAchievedButton": "Confirm",
-    "doNotMarkAsAchievedLink": "Do not add goal back into plan"
+    "confirmGoalReAddToPlan": "Confirm",
+    "doNotReAddGoalToPlan": "Do not add goal back into plan"
   }
 }

--- a/server/utils/commonLocale.json
+++ b/server/utils/commonLocale.json
@@ -83,7 +83,8 @@
       "noGoalNotes": "There are no notes on this goal yet.",
       "noteHeading": "{{ noteDate }} by {{ noteAuthor }}",
       "goalAchievedNote": "Goal marked as achieved on {{ noteDate }}.",
-      "goalRemovedNote": "Goal removed on {{ noteDate }}."
+      "goalRemovedNote": "Goal removed on {{ noteDate }}.",
+      "goalReAddedNote": "Goal added back into plan on {{ noteDate }}."
     },
     "backLink": {
       "text": "Back"

--- a/server/views/components/note-list/note-list.njk
+++ b/server/views/components/note-list/note-list.njk
@@ -16,11 +16,13 @@
                     }) %}
                     <label class="govuk-heading-s">{{ locale.noteHeading }}</label>
                     {% if note.type == "ACHIEVED" %}
-                        <p>{{ locale.goalAchievedNote }}</p>
+                        <p class="goal-status">{{ locale.goalAchievedNote }}</p>
                     {% elif note.type == "REMOVED" %}
-                        <p>{{ locale.goalRemovedNote }}</p>
+                      <p class="goal-status">{{ locale.goalRemovedNote }}</p>
+                      {% elif note.type == "READDED" %}
+                      <p class="goal-status">{{ locale.goalReAddedNote }}</p>
                     {% endif %}
-                    <p>{{ note.note }}</p>
+                    <p class="goal-note">{{ note.note }}</p>
                 {% endfor %}
             {% else %}
                 <p>{{ params.locale.common.noteList.noGoalNotes }}</p>

--- a/server/views/pages/confirm-re-add-goal.njk
+++ b/server/views/pages/confirm-re-add-goal.njk
@@ -145,13 +145,12 @@
           }) }}
 
           <div class="govuk-button-group">
-{#            todo: change button locale lookup name for confirm #}
               {{ govukButton({
-                  text: locale.confirmGoalAchievedButton,
+                  text: locale.confirmGoalReAddToPlan,
                   name: "action",
                   value: "confirm"
               }) }}
-              <a class="govuk-link govuk-link--no-visited-state" href="/plan?type={{ data.type }}">{{ locale.doNotMarkAsAchievedLink }}</a>
+              <a class="govuk-link govuk-link--no-visited-state" href="/view-removed-goal/{{ data.goal.uuid }}">{{ locale.doNotReAddGoalToPlan }}</a>
           </div>
         </form>
     </div>


### PR DESCRIPTION
This PR does four things:

1. Goal history (e.g on the Update details page) now includes the goal being readded to the plan on the goal notes as well as the plan history
2. The "Do not add goal back" button redirects the user back to the goal details page
3. The conditionally revealed form is open if there is an error with the data it contains
4. The tests in ReAddController.test.ts have been updated to remove mentioned of "achieve goal"