### PR TITLE
Add support for Apple Silicon M4 chips

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -11,6 +11,10 @@ services:
       - ../:/app:cached
       - node_modules:/app/node_modules
 
+  hmpps-auth:
+    environment:
+      JAVA_TOOL_OPTIONS: "-XX:UseSVE=0"
+
 volumes:
   node_modules:
     external: true

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -40,7 +40,6 @@ services:
       SPRING_PROFILES_ACTIVE: dev
       APPLICATION_AUTHENTICATION_UI_ALLOWLIST: 0.0.0.0/0
       LOGGING_LEVEL_ORG_SPRINGFRAMEWORK_SECURITY: DEBUG
-      JAVA_TOOL_OPTIONS: "-XX:UseSVE=0"
 
   arns-handover:
     image: quay.io/hmpps/hmpps-assess-risks-and-needs-handover-service:latest

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       SPRING_PROFILES_ACTIVE: dev
       APPLICATION_AUTHENTICATION_UI_ALLOWLIST: 0.0.0.0/0
       LOGGING_LEVEL_ORG_SPRINGFRAMEWORK_SECURITY: DEBUG
+      JAVA_TOOL_OPTIONS: "-XX:UseSVE=0"
 
   arns-handover:
     image: quay.io/hmpps/hmpps-assess-risks-and-needs-handover-service:latest


### PR DESCRIPTION
- Add `JAVA_TOOL_OPTIONS: "-XX:UseSVE=0"` environment variable to support running `hmpps-auth` on a M4 MacBook. 
- Short term solution to https://bugs.openjdk.org/browse/JDK-8345296