### PR TITLE
SP2-836 Adds proper "last updated" support

### DIFF
--- a/integration_tests/e2e/plan-overview.cy.ts
+++ b/integration_tests/e2e/plan-overview.cy.ts
@@ -182,6 +182,10 @@ describe('View Plan Overview for READ_WRITE user', () => {
           cy.visit('/plan')
           planOverview.agreePlan()
 
+          // we need to make sure the update comes 1 second after agreement for there to be a difference in the timestamps
+          // eslint-disable-next-line cypress/no-unnecessary-waiting
+          cy.wait(1000)
+
           // take any action on a goal that updates lastUpdated field
           cy.removeGoalFromPlan(goal.uuid, 'A removal note')
 

--- a/integration_tests/e2e/plan-overview.cy.ts
+++ b/integration_tests/e2e/plan-overview.cy.ts
@@ -24,50 +24,31 @@ describe('View Plan Overview for READ_WRITE user', () => {
     cy.checkAccessibility()
   })
 
-  it('Should have text saying no goals to work on now', () => {
+  it('Should not have `Agreed/Last updated/Created` text when Plan is not Agreed', () => {
     cy.visit('/plan')
-    cy.get('.govuk-grid-column-full').should('contain', 'does not have any goals to work on now. You can either:')
-    cy.checkAccessibility()
-  })
+    cy.get('.govuk-grid-column-full').should('not.contain', 'agreed to their plan on')
+    cy.get('.govuk-grid-column-full').should('not.contain', 'Last updated')
+    cy.get('.govuk-grid-column-full').should('not.contain', 'Plan created on')
 
-  it('Should have text saying no future goals present', () => {
-    cy.visit('/plan')
-    cy.get('.moj-sub-navigation__link').contains('Future goals').click()
-    cy.get('.govuk-grid-column-full').should('contain', 'does not have any future goals in their plan')
-    cy.checkAccessibility()
-  })
-
-  it('Should result in error when agree plan without goals', () => {
-    cy.visit('/plan')
-    cy.get('button').contains('Agree plan').click()
-    cy.title().should('contain', 'Error:')
-    cy.get('.govuk-error-summary').should('contain', 'To agree the plan, create a goal to work on now')
-    cy.checkAccessibility()
-  })
-
-  it('Should result in error when agree plan with future goal but no current goals', () => {
-    cy.get<{ plan: PlanType }>('@plan').then(({ plan }) => {
-      const newGoal = DataGenerator.generateGoal({ title: 'Test Accommodation' })
-      newGoal.targetDate = null
-      cy.addGoalToPlan(plan.uuid, newGoal)
-    })
-    cy.visit('/plan')
-    cy.get('button').contains('Agree plan').click()
-    cy.title().should('contain', 'Error:')
-    cy.get('.govuk-error-summary').should('contain', 'To agree the plan, create a goal to work on now')
-    cy.checkAccessibility()
-  })
-
-  it('Plan with goals and no steps should result into error when Agree plan', () => {
+    // also create a Goal and make sure the text still does not appear
     cy.get<{ plan: PlanType }>('@plan').then(({ plan }) => {
       cy.addGoalToPlan(plan.uuid, DataGenerator.generateGoal({ title: 'Test Accommodation' }))
       cy.visit('/plan')
     })
 
-    cy.get('button').contains('Agree plan').click()
-    cy.title().should('contain', 'Error:')
-    cy.get('.govuk-error-summary').should('contain', "Add steps to 'Test Accommodation'")
-    cy.get('.govuk-error-message').should('contain', "Add steps to 'Test Accommodation'")
+    cy.get('.govuk-grid-column-full').should('not.contain', 'Last updated')
+  })
+
+  it('Should have text saying no goals to work on now on Goals for now tab', () => {
+    cy.visit('/plan')
+    cy.get('.govuk-grid-column-full').should('contain', 'does not have any goals to work on now. You can either:')
+    cy.checkAccessibility()
+  })
+
+  it('Should have text saying no future goals present on Future goals tab', () => {
+    cy.visit('/plan')
+    cy.get('.moj-sub-navigation__link').contains('Future goals').click()
+    cy.get('.govuk-grid-column-full').should('contain', 'does not have any future goals in their plan')
     cy.checkAccessibility()
   })
 
@@ -104,71 +85,164 @@ describe('View Plan Overview for READ_WRITE user', () => {
     cy.checkAccessibility()
   })
 
-  it('Plan with valid goals and steps should go to agree-plan', () => {
-    cy.get<{ plan: PlanType }>('@plan').then(({ plan }) => {
-      cy.addGoalToPlan(plan.uuid, DataGenerator.generateGoal({ title: 'Test Accommodation' }))
+  describe('Tests for agreeing a plan', () => {
+    it('Agreeing a plan with no goals should result in error', () => {
       cy.visit('/plan')
+      cy.get('button').contains('Agree plan').click()
+      cy.title().should('contain', 'Error:')
+      cy.get('.govuk-error-summary').should('contain', 'To agree the plan, create a goal to work on now')
+      cy.checkAccessibility()
     })
-    cy.contains('a', 'Add steps').click()
 
-    const firstStep = DataGenerator.generateStep()
+    it('Agreeing a plan with a future goal but no current goals should result in error', () => {
+      cy.get<{ plan: PlanType }>('@plan').then(({ plan }) => {
+        const newGoal = DataGenerator.generateGoal({ title: 'Test Accommodation' })
+        newGoal.targetDate = null
+        cy.addGoalToPlan(plan.uuid, newGoal)
+      })
+      cy.visit('/plan')
+      cy.get('button').contains('Agree plan').click()
+      cy.title().should('contain', 'Error:')
+      cy.get('.govuk-error-summary').should('contain', 'To agree the plan, create a goal to work on now')
+      cy.checkAccessibility()
+    })
 
-    cy.get(`#step-actor-1`).select(firstStep.actor)
-    cy.get(`#step-description-1`).type('Accommodation')
-    cy.get('button').contains('Save and continue').click()
-    cy.get('button').contains('Agree plan').click()
-    cy.url().should('include', '/agree-plan')
-    cy.checkAccessibility()
-  })
-
-  it('Agreed plan can show when a goal was removed', () => {
-    cy.get<{ plan: PlanType }>('@plan').then(({ plan }) => {
-      cy.addGoalToPlan(plan.uuid, DataGenerator.generateGoal({ title: 'Test Accommodation' })).then(goal => {
-        cy.addStepToGoal(goal.uuid, DataGenerator.generateStep())
+    it('Agreeing a Plan with goals but no steps should result in error', () => {
+      cy.get<{ plan: PlanType }>('@plan').then(({ plan }) => {
+        cy.addGoalToPlan(plan.uuid, DataGenerator.generateGoal({ title: 'Test Accommodation' }))
         cy.visit('/plan')
       })
+
+      cy.get('button').contains('Agree plan').click()
+      cy.title().should('contain', 'Error:')
+      cy.get('.govuk-error-summary').should('contain', "Add steps to 'Test Accommodation'")
+      cy.get('.govuk-error-message').should('contain', "Add steps to 'Test Accommodation'")
+      cy.checkAccessibility()
     })
-    planOverview.agreePlan()
-    cy.contains('a', 'Update').click()
-    cy.contains('button', 'Remove goal from plan').click()
-    cy.get('#goal-removal-note').type('Removed during cypress test')
-    cy.get('button').contains('Confirm').click()
-    cy.get('.goal-date-and-notes > :nth-child(1)').contains('Removed on')
-    cy.get('.goal-date-and-notes > :nth-child(2)').contains('Removed during cypress test')
+
+    it('Agreeing a Plan with valid goals and steps should go to /agree-plan', () => {
+      cy.get<{ plan: PlanType }>('@plan').then(({ plan }) => {
+        cy.addGoalToPlan(plan.uuid, DataGenerator.generateGoal({ title: 'Test Accommodation' }))
+        cy.visit('/plan')
+      })
+      cy.contains('a', 'Add steps').click()
+
+      const firstStep = DataGenerator.generateStep()
+
+      cy.get(`#step-actor-1`).select(firstStep.actor)
+      cy.get(`#step-description-1`).type('Accommodation')
+      cy.get('button').contains('Save and continue').click()
+      cy.get('button').contains('Agree plan').click()
+      cy.url().should('include', '/agree-plan')
+      cy.checkAccessibility()
+    })
   })
 
-  it('Agreed plan shows validation error when goal has no steps', () => {
-    cy.get<{ plan: PlanType }>('@plan').then(({ plan }) => {
-      cy.addGoalToPlan(plan.uuid, DataGenerator.generateGoal({ title: 'Test Accommodation 1' })).then(goal => {
-        cy.addStepToGoal(goal.uuid, DataGenerator.generateStep())
-        planOverview.agreePlan()
-        cy.addGoalToPlan(plan.uuid, DataGenerator.generateGoal({ title: 'Test Accommodation 2' }))
+  describe('Tests for an Agreed Plan', () => {
+    it('Agreed plan shows message showing when it was agreed', () => {
+      cy.get<{ plan: PlanType }>('@plan').then(({ plan }) => {
+        cy.addGoalToPlan(plan.uuid, DataGenerator.generateGoal({ title: 'Test Accommodation' })).then(goal => {
+          cy.addStepToGoal(goal.uuid, DataGenerator.generateStep())
+          cy.visit('/plan')
+        })
       })
+      planOverview.agreePlan()
+      cy.get('.plan-header+p').should('contain', 'agreed to their plan on')
+      cy.get('.plan-header+p').should('not.contain', 'Last updated on')
     })
 
-    cy.visit('/plan')
-
-    cy.get('.govuk-error-summary').should('contain', "Add steps to 'Test Accommodation 2'")
-    cy.get('p.govuk-error-message').should('contain', "Add steps to 'Test Accommodation 2'")
-  })
-
-  it('Agreed plan does not show validation error when removed goal has no steps', () => {
-    cy.get<{ plan: PlanType }>('@plan').then(({ plan }) => {
-      cy.addGoalToPlan(plan.uuid, DataGenerator.generateGoal({ title: 'Test Accommodation 1' })).then(goal => {
-        cy.addStepToGoal(goal.uuid, DataGenerator.generateStep())
-        planOverview.agreePlan()
+    it('Agreed plan with `did not agree` shows message showing when it was created', () => {
+      cy.get<{ plan: PlanType }>('@plan').then(({ plan }) => {
+        cy.addGoalToPlan(plan.uuid, DataGenerator.generateGoal({ title: 'Test Accommodation' })).then(goal => {
+          cy.addStepToGoal(goal.uuid, DataGenerator.generateStep())
+          cy.visit('/plan')
+        })
       })
-
-      const secondGoal = DataGenerator.generateGoal({ title: 'Test Accommodation 2' })
-      cy.addGoalToPlan(plan.uuid, secondGoal).then(goal => {
-        cy.removeGoalFromPlan(goal.uuid, 'Reason for removing goal')
-      })
+      planOverview.agreePlanDidNotAgree()
+      cy.get('.plan-header+p').should('contain', 'Plan created on')
+      cy.get('.plan-header+p').should('not.contain', 'Last updated on')
     })
 
-    cy.visit('/plan')
+    it('Agreed plan with `could not answer` shows message showing when it was created', () => {
+      cy.get<{ plan: PlanType }>('@plan').then(({ plan }) => {
+        cy.addGoalToPlan(plan.uuid, DataGenerator.generateGoal({ title: 'Test Accommodation' })).then(goal => {
+          cy.addStepToGoal(goal.uuid, DataGenerator.generateStep())
+          cy.visit('/plan')
+        })
+      })
+      planOverview.agreePlanCouldNotAgree()
+      cy.get('.plan-header+p').should('contain', 'Plan created on')
+      cy.get('.plan-header+p').should('not.contain', 'Last updated on')
+    })
 
-    cy.get('.govuk-error-summary').should('not.exist')
-    cy.get('p.govuk-error-message').should('not.exist')
+    it('Agreed plan with updated goal shows message saying when it was last updated', () => {
+      cy.get<{ plan: PlanType }>('@plan').then(({ plan }) => {
+        cy.addGoalToPlan(plan.uuid, DataGenerator.generateGoal({ title: 'Test Accommodation' })).then(goal => {
+          cy.addStepToGoal(goal.uuid, DataGenerator.generateStep())
+          cy.visit('/plan')
+          planOverview.agreePlan()
+
+          // take any action on a goal that updates lastUpdated field
+          cy.removeGoalFromPlan(goal.uuid, 'A removal note')
+
+          // reload the page to see the updated message
+          cy.visit('/plan')
+        })
+      })
+
+      cy.get('.plan-header+p').should('not.contain', 'agreed to their plan on')
+      cy.get('.plan-header+p').should('contain', 'Last updated on')
+    })
+
+    it('Agreed plan can show when a goal was removed', () => {
+      cy.get<{ plan: PlanType }>('@plan').then(({ plan }) => {
+        cy.addGoalToPlan(plan.uuid, DataGenerator.generateGoal({ title: 'Test Accommodation' })).then(goal => {
+          cy.addStepToGoal(goal.uuid, DataGenerator.generateStep())
+          cy.visit('/plan')
+        })
+      })
+      planOverview.agreePlan()
+      cy.contains('a', 'Update').click()
+      cy.contains('button', 'Remove goal from plan').click()
+      cy.get('#goal-removal-note').type('Removed during cypress test')
+      cy.get('button').contains('Confirm').click()
+      cy.get('.goal-date-and-notes > :nth-child(1)').contains('Removed on')
+      cy.get('.goal-date-and-notes > :nth-child(2)').contains('Removed during cypress test')
+    })
+
+    it('Agreed plan shows validation error when goal has no steps', () => {
+      cy.get<{ plan: PlanType }>('@plan').then(({ plan }) => {
+        cy.addGoalToPlan(plan.uuid, DataGenerator.generateGoal({ title: 'Test Accommodation 1' })).then(goal => {
+          cy.addStepToGoal(goal.uuid, DataGenerator.generateStep())
+          planOverview.agreePlan()
+          cy.addGoalToPlan(plan.uuid, DataGenerator.generateGoal({ title: 'Test Accommodation 2' }))
+        })
+      })
+
+      cy.visit('/plan')
+
+      cy.get('.govuk-error-summary').should('contain', "Add steps to 'Test Accommodation 2'")
+      cy.get('p.govuk-error-message').should('contain', "Add steps to 'Test Accommodation 2'")
+    })
+
+    it('Agreed plan does not show validation error when removed goal has no steps', () => {
+      cy.get<{ plan: PlanType }>('@plan').then(({ plan }) => {
+        cy.addGoalToPlan(plan.uuid, DataGenerator.generateGoal({ title: 'Test Accommodation 1' })).then(goal => {
+          cy.addStepToGoal(goal.uuid, DataGenerator.generateStep())
+          planOverview.agreePlan()
+        })
+
+        const secondGoal = DataGenerator.generateGoal({ title: 'Test Accommodation 2' })
+        cy.addGoalToPlan(plan.uuid, secondGoal).then(goal => {
+          cy.removeGoalFromPlan(goal.uuid, 'Reason for removing goal')
+        })
+      })
+
+      cy.visit('/plan')
+
+      cy.get('.govuk-error-summary').should('not.exist')
+      cy.get('p.govuk-error-message').should('not.exist')
+    })
   })
 
   describe('Tests moving goals up and down', () => {

--- a/server/routes/planOverview/locale.json
+++ b/server/routes/planOverview/locale.json
@@ -17,9 +17,10 @@
       "deletedGoal": "You deleted a goal from {{ subject.possessiveName }} plan",
       "achievedGoal": "Congratulations on achieving a goal, {{ subject.givenName }}"
     },
-    "agreePlan": "{{ subject.givenName }} agreed to their plan on {{ plan.agreementDate }}",
-    "notAgreePlan": "Plan created on {{ plan.createdDate }}",
-    "lastUpdatedPlan": "Last updated on {{ plan.updatedDate }} by {{ plan.updatedBy }}.",
+    "agreePlan": "{{ subject.givenName }} agreed to their plan on {{ plan.agreementDate }}.",
+    "notAgreePlan": "Plan created on {{ plan.createdDate }}.",
+    "lastUpdatedPlan": "Last updated on {{ plan.mostRecentUpdateDate }} by {{ plan.mostRecentUpdateByName }}.",
+    "viewPlanHistory": "View plan history",
     "subNavigation": {
       "currentGoals": "Goals to work on now ({{ goalCounts.currentGoals }})",
       "futureGoals": "Future goals ({{ goalCounts.futureGoals }})",

--- a/server/views/pages/plan.njk
+++ b/server/views/pages/plan.njk
@@ -47,8 +47,8 @@
     plan: {
         agreementDate: data.plan.agreementDate | formatSimpleDate,
         createdDate: data.plan.createdDate | formatSimpleDate,
-        updatedDate: data.plan.updatedDate | formatSimpleDate,
-        updatedBy: data.plan.updatedBy.username | title
+        mostRecentUpdateDate: data.plan.mostRecentUpdateDate | formatSimpleDate,
+        mostRecentUpdateByName: data.plan.mostRecentUpdateByName | convertToTitleCase
     },
     subject: data.popData
 }) %}
@@ -95,12 +95,15 @@
     {{ super() }}
 
     {% if data.plan.agreementStatus === 'AGREED' %}
-      {#                {% if data.plan.updatedDate > data.plan.agreementDate %}#TODO: SP2-836#}
-      <p class="govuk-body govuk-!-margin-top-5">{{ locale.lastUpdatedPlan }}</p>
-      {#                {% else %}#}
-      {#                    <p class="govuk-body">{{ locale.agreePlan }}</p>#}
-      {#                {% endif %}#}
-    {% elseif data.plan.agreementStatus === 'DO_NOT_AGREE' %}
+      <p class="govuk-body govuk-!-margin-top-5">
+      {%- if data.plan.mostRecentUpdateDate > data.plan.agreementDate %}
+          {{ locale.lastUpdatedPlan }}
+      {%- else %}
+          {{ locale.agreePlan }}
+      {%- endif %}
+        <a href="/plan-history" class="govuk-link govuk-link--no-visited-state">{{ locale.viewPlanHistory }}</a>
+      </p>
+    {% elseif data.plan.agreementStatus === 'DO_NOT_AGREE' or data.plan.agreementStatus === 'COULD_NOT_ANSWER' %}
       <p class="govuk-body govuk-!-margin-top-5">{{ locale.notAgreePlan }}</p>
     {% elseif data.plan.agreementStatus === 'DRAFT' %}
       <p class="govuk-body govuk-!-margin-top-5">{{ locale.addStepSuggestion }}</p>


### PR DESCRIPTION
This uses the new "mostRecentUpdateDate" field from https://github.com/ministryofjustice/hmpps-sentence-plan/pull/166 in `plan.njk` to correctly display when the Plan or any of its Goals were last updated once a Plan is agreed.

As well as adding new tests it also refactors some of the tests in `plan-overview.cy.ts` into groups to make it more obvious where to look when doing updates.