### PR TITLE
SP2-1226 Go back to Delete Confirmation page from Change Goal page

### DIFF
--- a/integration_tests/e2e/change-goal.cy.ts
+++ b/integration_tests/e2e/change-goal.cy.ts
@@ -205,4 +205,16 @@ describe('Change a goal', () => {
       cy.checkAccessibility()
     })
   })
+
+  describe('Back behaviour', () => {
+    it('should go back to delete goal page if we came from the delete goal page', () => {
+      cy.get<{ plan: PlanType }>('@plan').then(({ plan }) => {
+        cy.addGoalToPlan(plan.uuid, goalData).then(goal => {
+          cy.visit(`/confirm-delete-goal/${goal.uuid}`)
+        })
+      })
+      cy.contains('a', 'change the goal').click()
+      cy.get('.govuk-back-link').should('have.attr', 'href').and('include', '/confirm-delete-goal/')
+    })
+  })
 })

--- a/server/routes/removeGoal/RemoveGoalController.test.ts
+++ b/server/routes/removeGoal/RemoveGoalController.test.ts
@@ -13,6 +13,7 @@ const mockGetPlanUUID = jest.fn().mockReturnValue(testPlan.uuid)
 const mockSessionService = jest.fn().mockImplementation(() => ({
   getPlanUUID: mockGetPlanUUID,
   getReturnLink: jest.fn().mockReturnValue(''),
+  setReturnLink: jest.fn(),
 }))
 
 jest.mock('../../middleware/authorisationMiddleware', () => ({

--- a/server/routes/removeGoal/RemoveGoalController.ts
+++ b/server/routes/removeGoal/RemoveGoalController.ts
@@ -29,11 +29,15 @@ export default class RemoveGoalController {
       const plan = await req.services.planService.getPlanByUuid(planUuid)
 
       const type = goalStatusToTabName(goal.status)
-      const returnLink = req.services.sessionService.getReturnLink()
+      const returnLink =
+        req.services.sessionService.getReturnLink() === `/confirm-delete-goal/${uuid}`
+          ? URLs.PLAN_OVERVIEW
+          : req.services.sessionService.getReturnLink()
 
       if (plan.agreementStatus === PlanAgreementStatus.DRAFT) {
         actionType = 'delete'
         localeType = localeDelete.en
+        req.services.sessionService.setReturnLink(`${URLs.DELETE_GOAL.replace(':uuid', uuid)}`)
       } else {
         actionType = 'remove'
         localeType = localeRemove.en
@@ -88,7 +92,7 @@ export default class RemoveGoalController {
     }
   }
 
-  private handleValidationErrors = (req: Request, res: Response, next: NextFunction) => {
+  private readonly handleValidationErrors = (req: Request, res: Response, next: NextFunction) => {
     if (Object.keys(req.errors.body).length && req.body.action === 'remove') {
       return this.render(req, res, next)
     }

--- a/server/routes/removeGoal/routes.test.ts
+++ b/server/routes/removeGoal/routes.test.ts
@@ -14,6 +14,7 @@ const mockSessionService = jest.fn().mockImplementation(() => ({
   getPrincipalDetails: jest.fn().mockReturnValue(handoverData.principal),
   getAccessMode: jest.fn().mockReturnValue('READ_WRITE'),
   getReturnLink: jest.fn().mockReturnValue(''),
+  setReturnLink: jest.fn(),
 }))
 
 jest.mock('../../services/sessionService', () => {


### PR DESCRIPTION
Updating the Back button behaviour of the Change goal page if we have come to that page via a link on the Delete goal page. 