### PR TITLE
SP2-1287: About page content changes

### DIFF
--- a/integration_tests/e2e/about.cy.ts
+++ b/integration_tests/e2e/about.cy.ts
@@ -14,7 +14,11 @@ describe('Rendering About Person for READ_WRITE user', () => {
     cy.get('.moj-primary-navigation__container').should('not.contain', `Plan history`)
     cy.get('h1').should('include.text', 'About')
     cy.get('h2').eq(0).contains('Sentence information')
+    cy.get('[id=last-updated]').contains('assessment was last updated on')
     cy.get('h2').eq(1).contains('High-scoring areas from the assessment')
+    cy.get('[id=other-areas-paragraph]').contains(
+      'Health and wellbeing, and finances never have a need score. When other information is available for those areas, you can see it here.',
+    )
     cy.get('[role="button"]').should('have.length', 2)
     cy.get('[role="button"]').eq(0).should('contain', 'Return to OASys')
     cy.get('[role="button"]').eq(1).should('contain', 'Create goal')
@@ -82,65 +86,88 @@ describe('Rendering About Person for READ_WRITE user', () => {
   })
 
   it('Should check if the data for (high-scoring area) thinking behaviour and attitudes are displayed correctly and in order', () => {
-    const expectedHeadings =
-      'This area is not linked to RoSH (risk of serious harm) ' +
-      'This area is not linked to risk of reoffending ' +
-      'Motivation to make changes in this area Sam wants to make changes but needs help. ' +
-      'There are no strengths or protective factors related to this area ' +
-      'Thinking, behaviours and attitudes need score ' +
-      '1 out of 10. (Scores above 2 are high-scoring.) ' +
-      '1 out of 10 ' +
-      'Lifestyle and associates need score ' +
-      '6 out of 6. (Scores above 1 are high-scoring.) ' +
-      '6 out of 6 ' +
-      'Create thinking, behaviours and attitudes goal'
+    const expectedHeadings = [
+      'This area is not linked to RoSH (risk of serious harm)',
+      'This area is not linked to risk of reoffending',
+      'Motivation to make changes in this area',
+      'There are no strengths or protective factors related to this area',
+      'Thinking, behaviours and attitudes need score',
+      'Lifestyle and associates need score',
+    ]
+
+    const expectedBody = [
+      'Sam wants to make changes but needs help.',
+      '1 out of 10. (Scores above 2 are high-scoring.)',
+      '1 out of 10',
+      '6 out of 6. (Scores above 1 are high-scoring.)',
+      '6 out of 6',
+    ]
+
     cy.get('.govuk-accordion__show-all').eq(0).click() // click show all in high-scoring assessment section
+
     cy.contains('.govuk-accordion__section', 'Thinking, behaviours and attitudes')
       .find('#accordion-default-content-3')
-      .invoke('text')
-      .then(text => {
-        const trimText = text.trim().replace(/\s+/g, ' ') // regex to catch and replace excessive newlines to single whitespace
-        expect(trimText).to.include(expectedHeadings)
-      })
-    cy.contains('.govuk-accordion__section', 'Thinking, behaviours and attitudes')
-      .find('.govuk-heading-s')
-      .should('have.length', 6)
-    cy.contains('.govuk-accordion__section', 'Thinking, behaviours and attitudes')
-      .find('.govuk-body')
-      .should('have.length', 6)
-  })
+      .as('sectionContent')
 
-  it('Should check if the score graph for (high-scoring area) thinking behaviour and attitudes is displayed correctly', () => {
-    cy.get('.govuk-accordion__show-all').eq(0).click()
-    cy.contains('.assessment-score', 'Thinking, behaviours and attitudes need score')
-      .find('.lowscoring')
-      .should('have.length', 1)
-    cy.contains('.assessment-score', 'Lifestyle and associates need score')
-      .find('.highscoring')
-      .should('have.length', 6)
+    // Header assertions
+    cy.get('@sectionContent')
+      .find('.govuk-heading-s')
+      .then(headerElements => {
+        const actualTitles = headerElements.toArray().map(header => header.textContent)
+        actualTitles.forEach((title, index) => {
+          expect(title).to.equal(expectedHeadings[index])
+        })
+      })
+
+    // Body assertions
+    cy.get('@sectionContent')
+      .find('.govuk-body')
+      .then(bodyElements => {
+        const actualBody = bodyElements.toArray().map(body => body.textContent.replace(/\s+/g, ' '))
+        actualBody.forEach((body, index) => {
+          expect(body).to.contain(expectedBody[index])
+        })
+      })
   })
 
   it('Should check if the data for (low-scoring area) drug use are displayed correctly and in order', () => {
-    const expectedHeadings =
-      'This area is not linked to RoSH (risk of serious harm) ' +
-      'This area is not linked to risk of reoffending ' +
-      'Motivation to make changes in this area ' +
-      'Sam is actively making changes. ' +
-      'There are no strengths or protective factors related to this area ' +
-      'Drug use need score ' +
-      '0 out of 8. (Scores above 0 are high-scoring.) ' +
-      '0 out of 8 ' +
-      'Create drug use goal'
-    cy.get('.govuk-accordion__show-all').eq(1).click() // click show all in low-scoring assessment section
-    cy.contains('.govuk-accordion__section', 'Drug use')
-      .find('#accordion-default-content-1')
-      .invoke('text')
-      .then(text => {
-        const trimText = text.trim().replace(/\s+/g, ' ') // regex to catch and replace excessive newlines to single whitespace
-        expect(trimText).to.include(expectedHeadings)
+    const expectedHeadings = [
+      'This area is not linked to RoSH (risk of serious harm)',
+      'This area is not linked to risk of reoffending',
+      'Motivation to make changes in this area',
+      'There are no strengths or protective factors related to this area',
+      'Drug use need score',
+    ]
+
+    const expectedBody = [
+      'Sam is actively making changes.',
+      '0 out of 8. (Scores above 0 are high-scoring.)',
+      '0 out of 8',
+    ]
+
+    cy.get('.govuk-accordion__show-all').eq(1).click() // click show all in high-scoring assessment section
+
+    cy.contains('.govuk-accordion__section', 'Drug use').find('#accordion-default-content-1').as('sectionContent')
+
+    // Header assertions
+    cy.get('@sectionContent')
+      .find('.govuk-heading-s')
+      .then(headerElements => {
+        const actualTitles = headerElements.toArray().map(header => header.textContent)
+        actualTitles.forEach((title, index) => {
+          expect(title).to.equal(expectedHeadings[index])
+        })
       })
-    cy.contains('.govuk-accordion__section', 'Drug use').find('.govuk-heading-s').should('have.length', 5)
-    cy.contains('.govuk-accordion__section', 'Drug use').find('.govuk-body').should('have.length', 4)
+
+    // Body assertions
+    cy.get('@sectionContent')
+      .find('.govuk-body')
+      .then(bodyElements => {
+        const actualBody = bodyElements.toArray().map(body => body.textContent.replace(/\s+/g, ' '))
+        actualBody.forEach((body, index) => {
+          expect(body).to.contain(expectedBody[index])
+        })
+      })
   })
 
   it('Should check if the score graph for (low-scoring area) drug use is displayed correctly', () => {
@@ -154,7 +181,7 @@ describe('Rendering About Person for READ_WRITE user', () => {
       'This area is not linked to risk of reoffending',
       'Motivation to make changes in this area',
       'There are no strengths or protective factors related to this area',
-      'This area does not have a need score',
+      'This area never has a need score',
     ]
 
     const expectedBody = ['There is no risk of serious harm', 'This question was not applicable.']
@@ -181,7 +208,6 @@ describe('Rendering About Person for READ_WRITE user', () => {
       .then(bodyElements => {
         const actualBody = bodyElements.toArray().map(body => body.textContent)
         actualBody.forEach((body, index) => {
-          cy.log(body)
           expect(body).to.contain(expectedBody[index])
         })
       })
@@ -193,7 +219,7 @@ describe('Rendering About Person for READ_WRITE user', () => {
       'This area is not linked to risk of reoffending',
       'Motivation to make changes in this area',
       'There are no strengths or protective factors related to this area',
-      'This area does not have a need score',
+      'This area never has a need score',
     ]
 
     const expectedBody = ['There is no risk of reoffending', 'This question was not applicable.', 'Nothing to add']

--- a/server/routes/aboutPerson/locale.json
+++ b/server/routes/aboutPerson/locale.json
@@ -11,7 +11,7 @@
       "endDateHeading": "Expected end date",
       "unpaidWorkHeading": "Unpaid work",
       "rarHeading": "RAR (Rehabilitation activity requirement)",
-      "lastUpdated": "Last updated on {{ lastUpdatedDate }}.",
+      "lastUpdated": "{{ subject.givenName }}'s assessment was last updated on {{ lastUpdatedDate }}.",
       "RoSH": "RoSH (Risk of Serious Harm)",
       "riskOfReoffending": "Risk of reoffending",
       "linkedToHarm": "This area is linked to RoSH (risk of serious harm)",
@@ -23,6 +23,18 @@
       "noStrengthsOrProtectiveFactors": "There are no strengths or protective factors related to this area",
       "needScore": "need score",
       "lifestyleAndAssociatesNeedScore": "Lifestyle and associates need score"
+    },
+    "lowScoring": {
+      "sectionHeading": "Low-scoring areas from the assessment",
+      "sectionEmptyParagraph": "No low-scoring areas."
+    },
+    "highScoring": {
+      "sectionHeading": "High-scoring areas from the assessment",
+      "sectionEmptyParagraph": "No high-scoring areas."
+    },
+    "withoutScoring": {
+      "sectionHeading": "Areas without a need score",
+      "sectionParagraph": "Health and wellbeing, and finances never have a need score. When other information is available for those areas, you can see it here."
     },
     "errors": {
       "noAssessmentDataFound": "No assessment data found",
@@ -44,7 +56,7 @@
       "summary": "Plan summary"
     },
     "needScore": {
-      "doesNotHaveNeedScore": "This area does not have a need score",
+      "doesNotHaveNeedScore": "This area never has a need score",
       "needScoreNotAvailable": "The score for this area is not available yet"
     }
   }

--- a/server/views/pages/about.njk
+++ b/server/views/pages/about.njk
@@ -47,9 +47,6 @@
 
 {% block content %}
     {{ super() }}
-    {% if data.formattedAssessmentInfo.versionUpdatedAt %}
-        <p class="govuk-body govuk-!-margin-top-5">{{ locale.detail.lastUpdated }}</p>
-    {% endif %}
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
@@ -65,7 +62,7 @@
             {% endif %}
 
             {% if data.deliusData.sentences.length > 0 %}
-            <h2 class="govuk-heading-m">Sentence information</h2>
+            <h2 class="govuk-heading-m govuk-!-margin-top-3">Sentence information</h2>
             <table class="govuk-table govuk-!-margin-bottom-6 sentence-info">
 
                 <tr class="govuk-body-s">
@@ -98,19 +95,30 @@
             </table>
             {% endif %}
 
+            {% if data.formattedAssessmentInfo.versionUpdatedAt %}
+                    <p id="last-updated" class="govuk-body govuk-!-margin-top-5">{{ locale.detail.lastUpdated }}</p>
+            {% endif %}
+
           {% if data.formattedAssessmentInfo.isAssessmentComplete %}
             {% if data.formattedAssessmentInfo.areas.highScoring.length > 0 %}
-                <h2 class="govuk-heading-m">High-scoring areas from the assessment</h2>
+                <h2 class="govuk-heading-m">{{ locale.highScoring.sectionHeading }}</h2>
                 {{ renderAssessment(data.formattedAssessmentInfo.areas.highScoring, locale, data.readWrite) }}
+            {% else %}
+                <h2 class="govuk-heading-m">{{ locale.highScoring.sectionHeading }}</h2>
+                <p class="govuk-body">{{ locale.highScoring.sectionEmptyParagraph }}</h2>
             {% endif %}
 
             {% if data.formattedAssessmentInfo.areas.lowScoring.length > 0 %}
-                <h2 class="govuk-heading-m">Low-scoring areas from the assessment</h2>
+                <h2 class="govuk-heading-m">{{ locale.lowScoring.sectionHeading }}</h2>
                 {{ renderAssessment(data.formattedAssessmentInfo.areas.lowScoring, locale, data.readWrite) }}
+            {% else %}
+                <h2 class="govuk-heading-m">{{ locale.lowScoring.sectionHeading }}</h2>
+                <p class="govuk-body">{{ locale.lowScoring.sectionEmptyParagraph }}</h2>
             {% endif %}
 
             {% if data.formattedAssessmentInfo.areas.other.length > 0 %}
-                <h2 class="govuk-heading-m">Areas without a need score</h2>
+                <h2 class="govuk-heading-m">{{ locale.withoutScoring.sectionHeading }}</h2>
+                <p id="other-areas-paragraph" class="govuk-body">{{ locale.withoutScoring.sectionParagraph }}</h2>
                 {{ renderAssessment(data.formattedAssessmentInfo.areas.other, locale, data.readWrite) }}
             {% endif %}
           {% else %}

--- a/server/views/pages/about.njk
+++ b/server/views/pages/about.njk
@@ -100,19 +100,18 @@
             {% endif %}
 
           {% if data.formattedAssessmentInfo.isAssessmentComplete %}
+
+            <h2 class="govuk-heading-m">{{ locale.highScoring.sectionHeading }}</h2>
             {% if data.formattedAssessmentInfo.areas.highScoring.length > 0 %}
-                <h2 class="govuk-heading-m">{{ locale.highScoring.sectionHeading }}</h2>
                 {{ renderAssessment(data.formattedAssessmentInfo.areas.highScoring, locale, data.readWrite) }}
             {% else %}
-                <h2 class="govuk-heading-m">{{ locale.highScoring.sectionHeading }}</h2>
                 <p class="govuk-body">{{ locale.highScoring.sectionEmptyParagraph }}</h2>
             {% endif %}
 
+            <h2 class="govuk-heading-m">{{ locale.lowScoring.sectionHeading }}</h2>
             {% if data.formattedAssessmentInfo.areas.lowScoring.length > 0 %}
-                <h2 class="govuk-heading-m">{{ locale.lowScoring.sectionHeading }}</h2>
                 {{ renderAssessment(data.formattedAssessmentInfo.areas.lowScoring, locale, data.readWrite) }}
             {% else %}
-                <h2 class="govuk-heading-m">{{ locale.lowScoring.sectionHeading }}</h2>
                 <p class="govuk-body">{{ locale.lowScoring.sectionEmptyParagraph }}</h2>
             {% endif %}
 


### PR DESCRIPTION
- Added paragraph for high/low scoring areas when they are empty.
- Extracted text from template into the locale file.
- Improved the remaining about.cy.ts tests to make it easier to see which assertion has failed.

![Screenshot 2025-02-13 at 08 54 45](https://github.com/user-attachments/assets/efe6031a-4211-4ed9-9287-89622750ddef)

