### PR TITLE
SP2-1283 incomplete assessment

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -96,6 +96,10 @@ a {
   border-bottom: 0;
 }
 
+.assessment-score {
+  @include govuk-responsive-margin(6, "bottom");
+}
+
 @include govuk-media-query($until: tablet) {
   .update-goal-table {
     border-collapse: separate !important; /* Prevents double borders in some browsers */

--- a/integration_tests/e2e/about.cy.ts
+++ b/integration_tests/e2e/about.cy.ts
@@ -13,12 +13,10 @@ describe('Rendering About Person for READ_WRITE user', () => {
   it('Should check the page rendered correctly', () => {
     cy.get('.moj-primary-navigation__container').should('not.contain', `Plan history`)
     cy.get('h1').should('include.text', 'About')
-    cy.get('h2').eq(0).contains('Sentence information')
-    cy.get('[id=last-updated]').contains('assessment was last updated on')
-    cy.get('h2').eq(1).contains('High-scoring areas from the assessment')
-    cy.get('[id=other-areas-paragraph]').contains(
-      'Health and wellbeing, and finances never have a need score. When other information is available for those areas, you can see it here.',
-    )
+    cy.get('h2.govuk-error-summary__title').eq(0).contains('Some areas have incomplete information')
+    cy.get('h2').eq(1).contains('Sentence information')
+    cy.get('h2').eq(2).contains('Incomplete information')
+    cy.get('h2').eq(3).contains('High-scoring areas from the assessment')
     cy.get('[role="button"]').should('have.length', 2)
     cy.get('[role="button"]').eq(0).should('contain', 'Return to OASys')
     cy.get('[role="button"]').eq(1).should('contain', 'Create goal')
@@ -42,8 +40,8 @@ describe('Rendering About Person for READ_WRITE user', () => {
 
   it('Should check if main titles of hard-coded high-scoring areas from the assessment are displayed correctly and in order with the correct risk marker', () => {
     const expectedText = [
-      'Accommodation',
       'Personal relationships and community',
+      'Accommodation',
       'Thinking, behaviours and attitudes',
       'Alcohol use',
       'Employment and education',
@@ -66,8 +64,8 @@ describe('Rendering About Person for READ_WRITE user', () => {
     cy.get('.govuk-accordion__show-all').click({ multiple: true })
 
     const areas = [
-      { text: 'Create accommodation goal', href: 'accommodation' },
       { text: 'Create personal relationships and community goal', href: 'personal-relationships-and-community' },
+      { text: 'Create accommodation goal', href: 'accommodation' },
       { text: 'Create thinking, behaviours and attitudes goal', href: 'thinking-behaviours-and-attitudes' },
       { text: 'Create alcohol use goal', href: 'alcohol-use' },
       { text: 'Create employment and education goal', href: 'employment-and-education' },

--- a/integration_tests/e2e/about.cy.ts
+++ b/integration_tests/e2e/about.cy.ts
@@ -271,8 +271,8 @@ describe('Rendering About Person in READ_ONLY', () => {
 
   it('Should check the page rendered correctly with no Create Goal button', () => {
     cy.get('h1').should('include.text', 'About')
-    cy.get('h2').eq(0).contains('Sentence information')
-    cy.get('h2').eq(1).contains('High-scoring areas from the assessment')
+    cy.get('h2').eq(1).contains('Sentence information')
+    cy.get('h2').eq(3).contains('High-scoring areas from the assessment')
     cy.get('[role="button"]').should('have.length', 1)
     cy.get('[role="button"]').eq(0).should('contain', 'Return to OASys')
   })

--- a/integration_tests/e2e/about.cy.ts
+++ b/integration_tests/e2e/about.cy.ts
@@ -1,3 +1,5 @@
+import { AccessMode } from '../../server/@types/Handover'
+
 describe('Rendering About Person for READ_WRITE user', () => {
   beforeEach(() => {
     cy.createSentencePlan().then(planDetails => {
@@ -71,7 +73,7 @@ describe('Rendering About Person for READ_WRITE user', () => {
     cy.get('#finances .moj-badge').should('not.exist')
     cy.get('#health-and-wellbeing .moj-badge').should('not.exist')
   })
-  /*
+
   it('Should check all hard-coded links in each assessment section are in the expected order', () => {
     cy.get('.govuk-accordion__show-all').click({ multiple: true })
 
@@ -281,5 +283,4 @@ describe('Rendering About Person in READ_ONLY', () => {
       expect(href).not.to.contain('create-goal')
     })
   })
-  */
 })

--- a/integration_tests/e2e/about.cy.ts
+++ b/integration_tests/e2e/about.cy.ts
@@ -1,5 +1,3 @@
-import { AccessMode } from '../../server/@types/Handover'
-
 describe('Rendering About Person for READ_WRITE user', () => {
   beforeEach(() => {
     cy.createSentencePlan().then(planDetails => {
@@ -55,11 +53,25 @@ describe('Rendering About Person for READ_WRITE user', () => {
   })
 
   it('Should check the hard-coded labels appear next to the correct, predetermined areas in correct order', () => {
-    cy.get('.govuk-accordion__section-heading').contains('Accommodation').contains('Risk of reoffending')
-    cy.get('.govuk-accordion__section-heading').contains('Alcohol use').contains('Risk of reoffending')
-    cy.get('.govuk-accordion__section-heading').contains('Employment and education').contains('Risk of reoffending')
-  })
+    // this is set to relLinkedToReoffending: 'YES', in backend.ts but doesn't display because the section is incomplete
+    cy.get('#personal-relationships-and-community .moj-badge').should('not.exist')
 
+    cy.get('#accommodation .moj-badge').should('have.length', 1)
+    cy.get('#accommodation .moj-badge').contains('Risk of reoffending')
+
+    cy.get('#thinking-behaviours-and-attitudes .moj-badge').should('not.exist')
+
+    cy.get('#alcohol-use .moj-badge').should('have.length', 1)
+    cy.get('#alcohol-use .moj-badge').contains('Risk of reoffending')
+
+    cy.get('#employment-and-education .moj-badge').should('have.length', 1)
+    cy.get('#employment-and-education .moj-badge').contains('Risk of reoffending')
+
+    cy.get('#drug-use .moj-badge').should('not.exist')
+    cy.get('#finances .moj-badge').should('not.exist')
+    cy.get('#health-and-wellbeing .moj-badge').should('not.exist')
+  })
+  /*
   it('Should check all hard-coded links in each assessment section are in the expected order', () => {
     cy.get('.govuk-accordion__show-all').click({ multiple: true })
 
@@ -269,4 +281,5 @@ describe('Rendering About Person in READ_ONLY', () => {
       expect(href).not.to.contain('create-goal')
     })
   })
+  */
 })

--- a/integration_tests/e2e/about.cy.ts
+++ b/integration_tests/e2e/about.cy.ts
@@ -97,6 +97,16 @@ describe('Rendering About Person for READ_WRITE user', () => {
     })
   })
 
+  it('Should check the Missing Information section in Personal Relationships and Community is displayed correctly', () => {
+    cy.get('.govuk-inset-text').should('have.length', 1) // make sure there is only one missing information section
+
+    cy.get('#personal-relationships-and-community button').click() // click show all in Personal Relationships and Community assessment section
+    cy.get('#personal-relationships-and-community .govuk-inset-text li').should('have.length', 1)
+    cy.get('#personal-relationships-and-community .govuk-inset-text li')
+      .eq(0)
+      .contains('whether this area is linked to RoSH (risk of serious harm)')
+  })
+
   it('Should check if the data for Thinking behaviour and attitudes are displayed correctly and in order', () => {
     const expectedHeadings = [
       'This area is not linked to RoSH (risk of serious harm)',

--- a/integration_tests/support/commands/backend.ts
+++ b/integration_tests/support/commands/backend.ts
@@ -101,7 +101,7 @@ function createHandoverContext(apiToken, oasysAssessmentPk, accessMode, sentence
         },
         personalRelationshipsAndCommunity: {
           relLinkedToHarm: 'NULL',
-          relLinkedToReoffending: 'NO',
+          relLinkedToReoffending: 'YES',
           relStrengths: 'NO',
           relOtherWeightedScore: '6',
           relThreshold: 'YES',

--- a/server/@types/Assessment.ts
+++ b/server/@types/Assessment.ts
@@ -29,6 +29,7 @@ export interface FormattedAssessment {
   isAssessmentComplete: boolean
   versionUpdatedAt?: string
   areas: {
+    incompleteAreas: AssessmentArea[]
     lowScoring: AssessmentArea[]
     highScoring: AssessmentArea[]
     other: AssessmentArea[]

--- a/server/routes/aboutPerson/locale.json
+++ b/server/routes/aboutPerson/locale.json
@@ -65,8 +65,7 @@
       "summary": "Plan summary"
     },
     "needScore": {
-      "doesNotHaveNeedScore": "This area never has a need score",
-      "needScoreNotAvailable": "The score for this area is not available yet"
+      "doesNotHaveNeedScore": "This area never has a need score"
     }
   }
 }

--- a/server/routes/aboutPerson/locale.json
+++ b/server/routes/aboutPerson/locale.json
@@ -48,8 +48,11 @@
       "viewPreviousGoalsLink": "View previous goals",
       "noPreviousGoals": "No previous goals"
     },
-    "assessmentIncomplete": {
-      "paragraphWithLink": "This information is not available yet because the assessment has not been completed. You can <a href='{{ oasysReturnUrl }}'>check the summary sheet in OASys</a> instead."
+    "incompleteAssessment": {
+      "errorTitle": "Some areas have incomplete information",
+      "errorDescription": "This means the areas have not been marked as complete in the assessment, but you can still see the latest information available.",
+      "sectionHeading": "Incomplete information",
+      "sectionParagraph": "These areas have not been marked as complete in the assessment yet, but you can see the latest information available."
     },
     "subNav": {
       "about": "About",

--- a/server/routes/aboutPerson/locale.json
+++ b/server/routes/aboutPerson/locale.json
@@ -14,13 +14,19 @@
       "lastUpdated": "{{ subject.givenName }}'s assessment was last updated on {{ lastUpdatedDate }}.",
       "RoSH": "RoSH (Risk of Serious Harm)",
       "riskOfReoffending": "Risk of reoffending",
-      "linkedToHarm": "This area is linked to RoSH (risk of serious harm)",
-      "notlinkedToHarm": "This area is not linked to RoSH (risk of serious harm)",
-      "linkedtoReoffending": "This area is linked to risk of reoffending",
-      "notLinkedToRiskOfReoffending": "This area is not linked to risk of reoffending",
+      "linkedToHarm": {
+        "yes": "This area is linked to RoSH (risk of serious harm)",
+        "no": "This area is not linked to RoSH (risk of serious harm)"
+      },
+      "linkedtoReoffending": {
+        "yes": "This area is linked to risk of reoffending",
+        "no": "This area is not linked to risk of reoffending"
+      },
       "motivationToMakeChanges": "Motivation to make changes in this area",
-      "strengthsOrProtectiveFactors": "There are strengths or protective factors related to this area",
-      "noStrengthsOrProtectiveFactors": "There are no strengths or protective factors related to this area",
+      "strengthsOrProtectiveFactors": {
+        "yes": "There are strengths or protective factors related to this area",
+        "no": "There are no strengths or protective factors related to this area"
+      },
       "needScore": "need score",
       "lifestyleAndAssociatesNeedScore": "Lifestyle and associates need score"
     },

--- a/server/routes/aboutPerson/locale.json
+++ b/server/routes/aboutPerson/locale.json
@@ -58,7 +58,8 @@
       "errorTitle": "Some areas have incomplete information",
       "errorDescription": "This means the areas have not been marked as complete in the assessment, but you can still see the latest information available.",
       "sectionHeading": "Incomplete information",
-      "sectionParagraph": "These areas have not been marked as complete in the assessment yet, but you can see the latest information available."
+      "sectionParagraph": "These areas have not been marked as complete in the assessment yet, but you can see the latest information available.",
+      "allInformationMissing": "No information is available yet"
     },
     "subNav": {
       "about": "About",

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -19,12 +19,18 @@ import {
 describe('format assessment data', () => {
   it('returns empty arrays when assessment is null', () => {
     const result = formatAssessmentData(fullCrimNeeds, null, areaConfigs)
-    expect(result).toEqual({ isAssessmentComplete: false, areas: { lowScoring: [], highScoring: [], other: [] } })
+    expect(result).toEqual({
+      isAssessmentComplete: false,
+      areas: { incompleteAreas: [], lowScoring: [], highScoring: [], other: [] },
+    })
   })
 
   it('returns empty arrays when assessment has no SAN data', () => {
     const result = formatAssessmentData(fullCrimNeeds, assessmentUndefined, areaConfigs)
-    expect(result).toEqual({ isAssessmentComplete: false, areas: { lowScoring: [], highScoring: [], other: [] } })
+    expect(result).toEqual({
+      isAssessmentComplete: false,
+      areas: { incompleteAreas: [], lowScoring: [], highScoring: [], other: [] },
+    })
   })
 
   it('returns correctly grouped assessment areas and incomplete assessment', () => {
@@ -70,8 +76,8 @@ describe('format assessment data', () => {
     const result = formatAssessmentData(fullCrimNeeds, incompleteAssessmentData, areaConfigs)
 
     expect(result.isAssessmentComplete).toEqual(false)
-    expect(result.areas.other[0].title).toEqual('Employment and education')
-    expect(result.areas.other[0].isAssessmentSectionComplete).toEqual(false)
+    expect(result.areas.incompleteAreas[2].title).toEqual('Employment and education')
+    expect(result.areas.incompleteAreas[2].isAssessmentSectionComplete).toEqual(false)
   })
 
   it('returns correctly ordered assessments by score compared to threshold in high scoring section', () => {

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -31,31 +31,34 @@ describe('format assessment data', () => {
     const result = formatAssessmentData(fullCrimNeeds, incompleteAssessmentData, areaConfigs)
     expect(result.isAssessmentComplete).toEqual(false)
 
-    expect(result.areas.highScoring.length).toEqual(2)
+    expect(result.areas.incompleteAreas.length).toEqual(5)
+    expect(result.areas.incompleteAreas[0].title).toEqual('Alcohol use')
+    expect(result.areas.incompleteAreas[1].title).toEqual('Drug use')
+    expect(result.areas.incompleteAreas[2].title).toEqual('Finances')
+
+    expect(result.areas.incompleteAreas[3].title).toEqual('Personal relationships and community')
+    expect(result.areas.incompleteAreas[3].overallScore).toEqual('6')
+    expect(result.areas.incompleteAreas[3].isAssessmentSectionComplete).toEqual(false)
+    expect(result.areas.incompleteAreas[4].title).toEqual('Thinking, behaviours and attitudes')
+    expect(result.areas.incompleteAreas[4].overallScore).toEqual('1')
+    expect(result.areas.incompleteAreas[4].isAssessmentSectionComplete).toEqual(false)
+
+    expect(result.areas.highScoring.length).toEqual(1)
     expect(result.areas.highScoring[0].title).toEqual('Accommodation')
     expect(result.areas.highScoring[0].overallScore).toEqual('6')
     expect(result.areas.highScoring[0].isAssessmentSectionComplete).toEqual(true)
-    expect(result.areas.highScoring[1].title).toEqual('Personal relationships and community')
-    expect(result.areas.highScoring[1].overallScore).toEqual('6')
-    expect(result.areas.highScoring[1].isAssessmentSectionComplete).toEqual(false)
 
-    expect(result.areas.lowScoring.length).toEqual(2)
+    expect(result.areas.lowScoring.length).toEqual(1)
     expect(result.areas.lowScoring[0].title).toEqual('Employment and education')
     expect(result.areas.lowScoring[0].overallScore).toEqual('1')
     expect(result.areas.lowScoring[0].isAssessmentSectionComplete).toEqual(true)
-    expect(result.areas.lowScoring[1].title).toEqual('Thinking, behaviours and attitudes')
-    expect(result.areas.lowScoring[1].overallScore).toEqual('1')
-    expect(result.areas.lowScoring[1].isAssessmentSectionComplete).toEqual(false)
 
-    expect(result.areas.other.length).toEqual(4)
-    expect(result.areas.other[0].title).toEqual('Alcohol use')
-    expect(result.areas.other[1].title).toEqual('Drug use')
-    expect(result.areas.other[2].title).toEqual('Finances')
-    expect(result.areas.other[3].title).toEqual('Health and wellbeing')
+    expect(result.areas.other.length).toEqual(1)
+    expect(result.areas.other[0].title).toEqual('Health and wellbeing')
 
     // Health and Wellbeing never has a score but should be marked as complete.
     // Only this Finance behave like this. Others need the score _and_ the `section_complete` flag.
-    expect(result.areas.other[3].isAssessmentSectionComplete).toEqual(true)
+    expect(result.areas.other[0].isAssessmentSectionComplete).toEqual(true)
 
     result.areas.other.forEach(otherArea => {
       expect(otherArea.overallScore).toBeUndefined()

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -239,11 +239,6 @@ export const motivationText = (optionResult?: string): string => {
   return camelCase(optionResult)
 }
 
-export const dateWithYear = (datetimeString: string): string | null => {
-  if (!datetimeString || isBlank(datetimeString)) return undefined
-  return DateTime.fromISO(datetimeString).toFormat('d MMMM yyyy')
-}
-
 export const yearsAndDaysElapsed = (datetimeStringFrom: string, datetimeStringTo: string): any => {
   return DateTime.fromISO(datetimeStringTo).diff(DateTime.fromISO(datetimeStringFrom), ['years', 'months', 'days'])
 }

--- a/server/utils/commonLocale.json
+++ b/server/utils/commonLocale.json
@@ -119,7 +119,8 @@
         "linkedToHarm": "whether this area is linked to RoSH (risk of serious harm)",
         "linkedToReoffending": "whether this area is linked to risk of reoffending",
         "motivationToMakeChanges": "motivation to make changes",
-        "linkedtoStrengthsOrProtectiveFactors": "strengths and protective factors"
+        "linkedtoStrengthsOrProtectiveFactors": "strengths and protective factors",
+        "criminogenicNeedsScore": "the need score"
       },
       "motivationToMakeChanges": "Motivation to make changes in this area",
       "motivationText": {

--- a/server/views/components/assessment/_area-assessment-summary.njk
+++ b/server/views/components/assessment/_area-assessment-summary.njk
@@ -50,12 +50,10 @@
   {# list out the missing information #}
   {% if missingInformation.length > 0 %}
     <p><strong>{{ locale.common.assessmentInfo.missingInformation }}</strong></p>
-    <p class="govuk-body">
     <ul>
       {% for info in missingInformation %}
         <li>{{ locale.common.assessmentInfo.missingInformationList[info] }}</li>
       {% endfor %}
     </ul>
-    </p>
   {% endif %}
 {% endif %}

--- a/server/views/components/assessment/_assessment-area.njk
+++ b/server/views/components/assessment/_assessment-area.njk
@@ -105,14 +105,17 @@
                 {% endif %} {# end of if assessment.criminogenicNeedMissing #}
 
                 {% if missingInformation.length > 0 %}
-                  <div class="govuk-inset-text">
-                      <p class="govuk-!-font-weight-bold">{{ locale.common.assessmentInfo.missingInformation }}</p>
-                      <ul>
-                      {% for info in missingInformation %}
-                          <li>{{ locale.common.assessmentInfo.missingInformationList[info] }}</li>
-                      {% endfor %}
-                      </ul>
-                  </div>
+                    <div class="govuk-inset-text">
+                        <p class="govuk-!-font-weight-bold">{{ locale.common.assessmentInfo.missingInformation }}</p>
+                        <ul>
+                        {% for info in missingInformation %}
+                            <li>{{ locale.common.assessmentInfo.missingInformationList[info] }}</li>
+                        {% endfor %}
+                        </ul>
+                    </div>
+                {% elseif missingInformation.length == 5 %}
+                    {# If all 5 displayed pieces of information are missing display a simplified message #}
+                    <p class="govuk-!-font-weight-bold">{{ locale.incompleteAssessment.allInformationMissing }}</p>
                 {% endif %}
 
                 {% if readWrite === true %}

--- a/server/views/components/assessment/_assessment-area.njk
+++ b/server/views/components/assessment/_assessment-area.njk
@@ -26,10 +26,13 @@
                     <p>This information isn't currently available, please check in OASys.</p>
                 {% else %}
 
+                    {% set missingInformation = [] %}
+
                     {# linked to harm #}
                     {% if assessment.linkedToHarm in ['YES', 'NO'] %}
                         <p class="govuk-!-font-weight-bold">{{ locale.detail.linkedToHarm[assessment.linkedToHarm | lower] }}</p>
-{#                   TODO else is null and add to missingInformation array   #}
+                    {% else %}
+                        {% set missingInformation = missingInformation.concat('linkedToHarm') %}
                     {% endif %}
                     {% if assessment.riskOfSeriousHarmDetails.length > 0 %}
                         <p class="sp-text-pre-wrap govuk-body">{{ assessment.riskOfSeriousHarmDetails }}</p>
@@ -38,7 +41,8 @@
                     {# linked to reoffending #}
                     {% if assessment.linkedtoReoffending in ['YES', 'NO'] %}
                         <p class="govuk-!-font-weight-bold">{{ locale.detail.linkedtoReoffending[assessment.linkedtoReoffending | lower] }}</p>
-{#                   TODO else is null and add to missingInformation array   #}
+                    {% else %}
+                      {% set missingInformation = missingInformation.concat('linkedToReoffending') %}
                     {% endif %}
                     {% if assessment.riskOfReoffendingDetails.length > 0 %}
                         <p class="sp-text-pre-wrap govuk-body">{{ assessment.riskOfReoffendingDetails }}</p>
@@ -48,11 +52,14 @@
                     {% if assessment.motivationToMakeChanges %}
                         <p class="govuk-!-font-weight-bold">{{ locale.detail.motivationToMakeChanges }}</p>
                         <p class="govuk-body">{{ locale.common.assessmentInfo.motivationText[assessment.motivationToMakeChanges] }}</p>
+                    {% else %}
+                      {% set missingInformation = missingInformation.concat('motivationToMakeChanges') %}
                     {% endif %}
 
                     {% if assessment.linkedtoStrengthsOrProtectiveFactors in ['YES', 'NO'] %}
                         <p class="govuk-!-font-weight-bold">{{ locale.detail.strengthsOrProtectiveFactors[assessment.linkedtoStrengthsOrProtectiveFactors | lower] }}</p>
-{#                      todo else missing info #}
+                    {% else %}
+                      {% set missingInformation = missingInformation.concat('linkedtoStrengthsOrProtectiveFactors') %}
                     {% endif %}
                     {% if assessment.strengthsOrProtectiveFactorsDetails.length > 0 %}
                       <p class="sp-text-pre-wrap govuk-body">{{ assessment.strengthsOrProtectiveFactorsDetails }}</p>
@@ -74,7 +81,7 @@
                         {% if assessment.title in ['Finances', 'Health and wellbeing'] %}
                             <p class="govuk-!-font-weight-bold">{{ locale.needScore.doesNotHaveNeedScore }}</p>
                         {% else %}
-                            <p class="govuk-!-font-weight-bold">{{ locale.needScore.needScoreNotAvailable }}</p>
+                          {% set missingInformation = missingInformation.concat('criminogenicNeedsScore') %}
                         {% endif %}
                     {% endif %}
 
@@ -95,13 +102,24 @@
                             </div>
                         </div>
                     {% endif %}
+                {% endif %} {# end of if assessment.criminogenicNeedMissing #}
+
+                {% if missingInformation.length > 0 %}
+                  <div class="govuk-inset-text">
+                      <p class="govuk-!-font-weight-bold">{{ locale.common.assessmentInfo.missingInformation }}</p>
+                      <ul>
+                      {% for info in missingInformation %}
+                          <li>{{ locale.common.assessmentInfo.missingInformationList[info] }}</li>
+                      {% endfor %}
+                      </ul>
+                  </div>
                 {% endif %}
 
-              {% if readWrite === true %}
-                  <p class='goal-link'>
-                    <a href='/create-goal/{{ assessment.goalRoute }}'>Create {{ assessment.title | lower }} goal</a>
-                  </p>
-              {% endif %}
+                {% if readWrite === true %}
+                    <p class='goal-link'>
+                        <a href='/create-goal/{{ assessment.goalRoute }}'>Create {{ assessment.title | lower }} goal</a>
+                    </p>
+                {% endif %}
             </div>
         </div>
     {% endfor %}

--- a/server/views/components/assessment/_assessment-area.njk
+++ b/server/views/components/assessment/_assessment-area.njk
@@ -3,16 +3,13 @@
 
 <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default-{{ loop.index }}">
     {% for assessment in formattedAssessments %}
-        {% set riskOfSeriousHarmData = assessment.riskOfSeriousHarmDetails %}
-        {% set riskOfReoffendingData = assessment.riskOfReoffendingDetails %}
-        {% set strengthsOrProtectiveFactorsData = assessment.strengthsOrProtectiveFactorsDetails %}
         <div class="govuk-accordion__section" id="{{ assessment.goalRoute }}">
             <div class="govuk-accordion__section-header">
                 <h3 class="govuk-accordion__section-heading">
-                      <span class="govuk-accordion__section-button sp-accordion-header"
-                            id="accordion-default-heading-{{ loop.index }}">
-                        {{ assessment.title }}
-                      </span>
+                    <span class="govuk-accordion__section-button sp-accordion-header"
+                          id="accordion-default-heading-{{ loop.index }}">
+                      {{ assessment.title }}
+                    </span>
                 </h3>
                 <div class="govuk-accordion__section-summary govuk-body sp-accordion-tags"
                      id="accordion-with-summary-sections-summary-{{ loop.index }}">
@@ -28,54 +25,37 @@
                 {% if assessment.criminogenicNeedMissing %}
                     <p>This information isn't currently available, please check in OASys.</p>
                 {% else %}
-                    {% if assessment.linkedToHarm === 'YES' %}
-                        <div class="rosh">
-                            <p class="govuk-!-font-weight-bold">{{ locale.detail.linkedToHarm }}</p>
-                            <p class="govuk-body">{{ riskOfSeriousHarmData }}</p>
-                        </div>
-                    {% elseif assessment.linkedToHarm === 'NO' and riskOfSeriousHarmData %}
-                        <div class="rosh">
-                            <p class="govuk-!-font-weight-bold">{{ locale.detail.notlinkedToHarm }}</p>
-                            <p class="govuk-body">{{ riskOfSeriousHarmData }}</p>
-                        </div>
-                    {% else %}
-                        <p class="govuk-!-font-weight-bold">{{ locale.detail.notlinkedToHarm }}</p>
+
+                    {# linked to harm #}
+                    {% if assessment.linkedToHarm in ['YES', 'NO'] %}
+                        <p class="govuk-!-font-weight-bold">{{ locale.detail.linkedToHarm[assessment.linkedToHarm | lower] }}</p>
+{#                   TODO else is null and add to missingInformation array   #}
+                    {% endif %}
+                    {% if assessment.riskOfSeriousHarmDetails.length > 0 %}
+                        <p class="sp-text-pre-wrap govuk-body">{{ assessment.riskOfSeriousHarmDetails }}</p>
                     {% endif %}
 
-
-                    {% if assessment.linkedtoReoffending === 'YES' %}
-                        <div class="ror">
-                            <p class="govuk-!-font-weight-bold">{{ locale.detail.linkedtoReoffending }}</p>
-                            <p class="sp-text-pre-wrap govuk-body">{{ riskOfReoffendingData }}</p>
-                        </div>
-                    {% elseif assessment.linkedtoReoffending === 'NO' and riskOfReoffendingData %}
-                        <div class="ror">
-                            <p class="govuk-!-font-weight-bold">{{ locale.detail.notLinkedToRiskOfReoffending }}</p>
-                            <p class="sp-text-pre-wrap govuk-body">{{ riskOfReoffendingData }}</p>
-                        </div>
-                    {% else %}
-                        <p class="govuk-!-font-weight-bold">{{ locale.detail.notLinkedToRiskOfReoffending }}</p>
+                    {# linked to reoffending #}
+                    {% if assessment.linkedtoReoffending in ['YES', 'NO'] %}
+                        <p class="govuk-!-font-weight-bold">{{ locale.detail.linkedtoReoffending[assessment.linkedtoReoffending | lower] }}</p>
+{#                   TODO else is null and add to missingInformation array   #}
+                    {% endif %}
+                    {% if assessment.riskOfReoffendingDetails.length > 0 %}
+                        <p class="sp-text-pre-wrap govuk-body">{{ assessment.riskOfReoffendingDetails }}</p>
                     {% endif %}
 
+                    {# motivation #}
                     {% if assessment.motivationToMakeChanges %}
-                        <div class="motivation">
-                            <p class="govuk-!-font-weight-bold">{{ locale.detail.motivationToMakeChanges }}</p>
-                            <p class="govuk-body">{{ locale.common.assessmentInfo.motivationText[assessment.motivationToMakeChanges] }}</p>
-                        </div>
+                        <p class="govuk-!-font-weight-bold">{{ locale.detail.motivationToMakeChanges }}</p>
+                        <p class="govuk-body">{{ locale.common.assessmentInfo.motivationText[assessment.motivationToMakeChanges] }}</p>
                     {% endif %}
 
-                    {% if assessment.linkedtoStrengthsOrProtectiveFactors === 'YES' %}
-                        <div class="strengths">
-                            <p class="govuk-!-font-weight-bold">{{ locale.detail.strengthsOrProtectiveFactors }}</p>
-                            <p class="sp-text-pre-wrap govuk-body">{{ strengthsOrProtectiveFactorsData }}</p>
-                        </div>
-                    {% elseif assessment.linkedtoStrengthsOrProtectiveFactors === 'NO' and strengthsOrProtectiveFactorsData %}
-                        <div class="strengths">
-                          <p class="govuk-!-font-weight-bold">{{ locale.detail.noStrengthsOrProtectiveFactors }}</p>
-                          <p class="sp-text-pre-wrap govuk-body">{{ strengthsOrProtectiveFactorsData }}</p>
-                        </div>
-                    {% else %}
-                        <p class="govuk-!-font-weight-bold">{{ locale.detail.noStrengthsOrProtectiveFactors }}</p>
+                    {% if assessment.linkedtoStrengthsOrProtectiveFactors in ['YES', 'NO'] %}
+                        <p class="govuk-!-font-weight-bold">{{ locale.detail.strengthsOrProtectiveFactors[assessment.linkedtoStrengthsOrProtectiveFactors | lower] }}</p>
+{#                      todo else missing info #}
+                    {% endif %}
+                    {% if assessment.strengthsOrProtectiveFactorsDetails.length > 0 %}
+                      <p class="sp-text-pre-wrap govuk-body">{{ assessment.strengthsOrProtectiveFactorsDetails }}</p>
                     {% endif %}
 
                     {% if assessment.criminogenicNeedsScore %}
@@ -99,7 +79,6 @@
                     {% endif %}
 
                     {% if assessment.subData %}
-                        <br>
                         <div class="assessment-score">
                             <p class="govuk-!-font-weight-bold">{{ locale.detail.lifestyleAndAssociatesNeedScore }}</p>
                             <p class="govuk-body">{{ assessment.subData.criminogenicNeedsScore }} out
@@ -115,17 +94,13 @@
                                 </div>
                             </div>
                         </div>
-                        <br>
                     {% endif %}
                 {% endif %}
 
               {% if readWrite === true %}
-                <div>
-                    <p class='goal-link'>
-                      <a href='/create-goal/{{ assessment.goalRoute }}'
-                        >Create {{ assessment.title | lower }} goal</a>
-                    </p>
-                </div>
+                  <p class='goal-link'>
+                    <a href='/create-goal/{{ assessment.goalRoute }}'>Create {{ assessment.title | lower }} goal</a>
+                  </p>
               {% endif %}
             </div>
         </div>

--- a/server/views/components/assessment/_assessment-area.njk
+++ b/server/views/components/assessment/_assessment-area.njk
@@ -16,10 +16,10 @@
                 </h3>
                 <div class="govuk-accordion__section-summary govuk-body sp-accordion-tags"
                      id="accordion-with-summary-sections-summary-{{ loop.index }}">
-                    {% if assessment.linkedToHarm === 'YES' %}
+                    {% if assessment.isAssessmentSectionComplete and assessment.linkedToHarm === 'YES' %}
                         <span class="moj-badge moj-badge--large moj-badge--purple sp-badge">{{ locale.detail.RoSH }}</span>
                     {% endif %}
-                    {% if assessment.linkedtoReoffending === 'YES' %}
+                    {% if assessment.isAssessmentSectionComplete and assessment.linkedtoReoffending === 'YES' %}
                         <span class="moj-badge moj-badge--large moj-badge--bright-purple sp-badge">{{ locale.detail.riskOfReoffending }}</span>
                     {% endif %}
                 </div>

--- a/server/views/pages/about.njk
+++ b/server/views/pages/about.njk
@@ -51,14 +51,21 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             {% if errors.domain %}
-            {%  set errorList = [] %}
-            {%  for error in errors.domain %}
-                {%  set errorList = (errorList.push({ text: locale.errors[error]}), errorList)    %}
-            {%  endfor %}
-                {{ govukErrorSummary({
-                    titleText: "There is a problem",
-                    errorList: errorList
-                }) }}
+                {%  set errorList = [] %}
+                {%  for error in errors.domain %}
+                    {%  set errorList = (errorList.push({ text: locale.errors[error]}), errorList)    %}
+                {%  endfor %}
+                    {{ govukErrorSummary({
+                        titleText: "There is a problem",
+                        errorList: errorList
+                    }) }}
+            {% endif %}
+
+            {% if not data.formattedAssessmentInfo.isAssessmentComplete %}
+              {{ govukErrorSummary({
+                  titleText: locale.incompleteAssessment.errorTitle,
+                  descriptionText: locale.incompleteAssessment.errorDescription
+              }) }}
             {% endif %}
 
             {% if data.deliusData.sentences.length > 0 %}
@@ -99,7 +106,11 @@
                     <p id="last-updated" class="govuk-body govuk-!-margin-top-5">{{ locale.detail.lastUpdated }}</p>
             {% endif %}
 
-          {% if data.formattedAssessmentInfo.isAssessmentComplete %}
+          {% if data.formattedAssessmentInfo.areas.incompleteAreas.length > 0 %}
+            <h2 class="govuk-heading-m">{{ locale.incompleteAssessment.sectionHeading }}</h2>
+            <p class="govuk-body">{{ locale.incompleteAssessment.sectionParagraph }}</p>
+            {{ renderAssessment(data.formattedAssessmentInfo.areas.incompleteAreas, locale, data.readWrite) }}
+          {% endif %}
 
             <h2 class="govuk-heading-m">{{ locale.highScoring.sectionHeading }}</h2>
             {% if data.formattedAssessmentInfo.areas.highScoring.length > 0 %}
@@ -120,12 +131,6 @@
                 <p id="other-areas-paragraph" class="govuk-body">{{ locale.withoutScoring.sectionParagraph }}</h2>
                 {{ renderAssessment(data.formattedAssessmentInfo.areas.other, locale, data.readWrite) }}
             {% endif %}
-          {% else %}
-            {{ govukWarningText({
-              html: '<strong>' + locale.assessmentIncomplete.paragraphWithLink + '</strong>',
-              iconFallbackText: "Warning"
-            }) }}
-          {% endif %}
 
         </div>
 

--- a/wiremock/mappings/assessment.json
+++ b/wiremock/mappings/assessment.json
@@ -2072,7 +2072,7 @@
                   "text": "No"
                 }
               ],
-              "value": "YES",
+              "value": "NO",
               "values": null,
               "collection": null
             },


### PR DESCRIPTION
This PR adds support for separately displaying incomplete assessment areas on the /about page.

Support for grouping those areas is in `server/utils/assessmentUtils.ts` with the relevant Type updated in `server/@types/Assessment.ts`

I have removed the temporary fix from `server/views/pages/about.njk` which displays a warning when the assessment is incomplete, and used the same `renderAssessment` component to display the new incomplete assessment areas.

I have updated `server/views/components/assessment/_assessment-area.njk` to allow for the new requirements of this story and also simplified the existing templating and locale logic as well as adding the new “Missing information” section - all of this is modeled on `server/views/components/assessment/_area-assessment-summary.njk` to which I also made a small HTML change to align the two components.

In `integration_tests/support/commands/backend.ts` I changed a relLinkedToReoffending value for an incomplete assessment area from NO to YES so that it could be tested in `about.cy.ts`.

Not strictly necessary but I also removed some uses of `<br>` from about.njk and replaced with the equivalent margin distance on the preceding divs by adding a line to `local.scss`.

Screenshot:

<img src="https://github.com/user-attachments/assets/26d4c0eb-18c1-4fd2-acaa-a5fe9d932892" width="100px">

