### PR TITLE
SP2-1283: Design changes

### DIFF
--- a/integration_tests/e2e/about.cy.ts
+++ b/integration_tests/e2e/about.cy.ts
@@ -13,7 +13,7 @@ describe('Rendering About Person for READ_WRITE user', () => {
   it('Should check the page rendered correctly', () => {
     cy.get('.moj-primary-navigation__container').should('not.contain', `Plan history`)
     cy.get('h1').should('include.text', 'About')
-    cy.get('h2.govuk-error-summary__title').eq(0).contains('Some areas have incomplete information')
+    cy.get('h2.govuk-heading-m').eq(0).contains('Some areas have incomplete information')
     cy.get('h2').eq(1).contains('Sentence information')
     cy.get('h2').eq(2).contains('Incomplete information')
     cy.get('h2').eq(3).contains('High-scoring areas from the assessment')

--- a/server/utils/commonLocale.json
+++ b/server/utils/commonLocale.json
@@ -113,7 +113,7 @@
       "detailsSummary": "View information from {{ subject.possessiveName }} assessment",
       "assessmentIncomplete": "This area has not been marked as complete in the assessment yet, but you can check the latest information available below.",
       "assessmentNotStarted": "No information is available yet as the assessment has not been started for this area.",
-      "missingInformation": "Missing information",
+      "missingInformation": "Missing information:",
       "assessmentUnavailable": "There is a problem getting this information. Try reloading the page or try again later.",
       "missingInformationList": {
         "linkedToHarm": "whether this area is linked to RoSH (risk of serious harm)",

--- a/server/views/pages/about.njk
+++ b/server/views/pages/about.njk
@@ -61,10 +61,18 @@
                     }) }}
             {% endif %}
 
+            {% set bannerContent = "
+                <h2 class='govuk-heading-m'>" ~ locale.incompleteAssessment.errorTitle ~ "</h2>
+                <p class='govuk-body'>" ~ locale.incompleteAssessment.errorDescription ~ "</p>
+            "%}
+
+
+
             {% if not data.formattedAssessmentInfo.isAssessmentComplete %}
-              {{ govukErrorSummary({
-                  titleText: locale.incompleteAssessment.errorTitle,
-                  descriptionText: locale.incompleteAssessment.errorDescription
+              {{ mojBanner({
+                type: 'warning',
+                html: bannerContent,
+                iconFallbackText: 'Warning'
               }) }}
             {% endif %}
 
@@ -126,9 +134,9 @@
                 <p class="govuk-body">{{ locale.lowScoring.sectionEmptyParagraph }}</h2>
             {% endif %}
 
+            <h2 class="govuk-heading-m">{{ locale.withoutScoring.sectionHeading }}</h2>
+            <p id="other-areas-paragraph" class="govuk-body">{{ locale.withoutScoring.sectionParagraph }}</h2>
             {% if data.formattedAssessmentInfo.areas.other.length > 0 %}
-                <h2 class="govuk-heading-m">{{ locale.withoutScoring.sectionHeading }}</h2>
-                <p id="other-areas-paragraph" class="govuk-body">{{ locale.withoutScoring.sectionParagraph }}</h2>
                 {{ renderAssessment(data.formattedAssessmentInfo.areas.other, locale, data.readWrite) }}
             {% endif %}
 

--- a/server/views/pages/about.njk
+++ b/server/views/pages/about.njk
@@ -66,8 +66,6 @@
                 <p class='govuk-body'>" ~ locale.incompleteAssessment.errorDescription ~ "</p>
             "%}
 
-
-
             {% if not data.formattedAssessmentInfo.isAssessmentComplete %}
               {{ mojBanner({
                 type: 'warning',


### PR DESCRIPTION
- Changes error  summary banner to a warning banner
- Displays 'Areas without a score' regardless of if the section is populated or not
- Adds missing colon to 'Missing Information'