### PR TITLE
SP2-1388: Update error summary cards to utilise common locale instead

### DIFF
--- a/server/views/components/error-summary/error-summary.njk
+++ b/server/views/components/error-summary/error-summary.njk
@@ -12,7 +12,7 @@
 
     {% if errorList.length %}
         {{ govukErrorSummary({
-            titleText: "There is a problem",
+            titleText: locale.common.errorSummaryCard.title,
             errorList: errorList
         }) }}
     {% endif %}

--- a/server/views/pages/about.njk
+++ b/server/views/pages/about.njk
@@ -56,7 +56,7 @@
                     {%  set errorList = (errorList.push({ text: locale.errors[error]}), errorList)    %}
                 {%  endfor %}
                     {{ govukErrorSummary({
-                        titleText: "There is a problem",
+                        titleText: locale.common.errorSummaryCard.title,
                         errorList: errorList
                     }) }}
             {% endif %}

--- a/server/views/pages/agree-plan.njk
+++ b/server/views/pages/agree-plan.njk
@@ -2,7 +2,7 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "../components/error-summary/error-summary.njk" import errorSummary %}
+{% from "../components/error-summary/error-summary.njk" import errorSummary with context %}
 
 {% block pageTitle %}
     {% if not errors %}

--- a/server/views/pages/change-goal.njk
+++ b/server/views/pages/change-goal.njk
@@ -4,7 +4,7 @@
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
-{% from "../components/error-summary/error-summary.njk" import errorSummary %}
+{% from "../components/error-summary/error-summary.njk" import errorSummary with context %}
 {% from "moj/components/date-picker/macro.njk" import mojDatePicker %}
 {% from "moj/components/side-navigation/macro.njk" import mojSideNavigation %}
 {% from "../components/assessment/area-assessment-summary.njk" import assessmentInformationForArea %}

--- a/server/views/pages/confirm-achieved-goal.njk
+++ b/server/views/pages/confirm-achieved-goal.njk
@@ -2,7 +2,7 @@
 {% from "../components/summary-card/goal-summary-card.njk" import goalSummaryCard %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "../components/error-summary/error-summary.njk" import errorSummary %}
+{% from "../components/error-summary/error-summary.njk" import errorSummary with context %}
 
 {% block pageTitle %}
     {% if not errors %}

--- a/server/views/pages/confirm-if-achieved.njk
+++ b/server/views/pages/confirm-if-achieved.njk
@@ -3,7 +3,7 @@
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "../components/error-summary/error-summary.njk" import errorSummary %}
+{% from "../components/error-summary/error-summary.njk" import errorSummary with context %}
 
 {% block pageTitle %}
     {% if not errors %}

--- a/server/views/pages/confirm-re-add-goal.njk
+++ b/server/views/pages/confirm-re-add-goal.njk
@@ -6,7 +6,7 @@
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "moj/components/date-picker/macro.njk" import mojDatePicker %}
 {% from "../components/summary-card/goal-summary-card.njk" import goalSummaryCard %}
-{% from "../components/error-summary/error-summary.njk" import errorSummary %}
+{% from "../components/error-summary/error-summary.njk" import errorSummary with context %}
 
 {% set locale = interpolate(locale, {
   dateOptions: {

--- a/server/views/pages/create-goal.njk
+++ b/server/views/pages/create-goal.njk
@@ -6,7 +6,7 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "moj/components/side-navigation/macro.njk" import mojSideNavigation %}
 {% from "moj/components/date-picker/macro.njk" import mojDatePicker %}
-{% from "../components/error-summary/error-summary.njk" import errorSummary %}
+{% from "../components/error-summary/error-summary.njk" import errorSummary with context %}
 {% from "../components/assessment/area-assessment-summary.njk" import assessmentInformationForArea %}
 
 {% set locale = interpolate(locale, {

--- a/server/views/pages/plan.njk
+++ b/server/views/pages/plan.njk
@@ -5,7 +5,6 @@
 {%- from "moj/components/banner/macro.njk" import mojBanner -%}
 {% from "../components/summary-card/goal-summary-card.njk" import goalSummaryCard %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "../components/error-summary/error-summary.njk" import errorSummary %}
 {% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
 
 {% set currentGoals = [] %}
@@ -139,7 +138,7 @@
 
             {% if data.readWrite == true and errors.domain | length > 0 %}
                 {{ govukErrorSummary({
-                    titleText: "There is a problem",
+                    titleText: locale.common.errorSummaryCard.title,
                     errorList: errorList
                 }) }}
             {% endif %}

--- a/server/views/pages/remove-goal.njk
+++ b/server/views/pages/remove-goal.njk
@@ -2,7 +2,7 @@
 {% from "../components/summary-card/goal-summary-card.njk" import goalSummaryCard %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
-{% from "../components/error-summary/error-summary.njk" import errorSummary %}
+{% from "../components/error-summary/error-summary.njk" import errorSummary with context %}
 
 {% set locale = interpolate(locale, {
     goalUuid: data.goal.uuid

--- a/server/views/pages/update-goal.njk
+++ b/server/views/pages/update-goal.njk
@@ -4,7 +4,7 @@
 {% from "../components/summary-card/goal-summary-card.njk" import goalSummaryCard %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "../components/note-list/note-list.njk" import noteList %}
-{% from "../components/error-summary/error-summary.njk" import errorSummary %}
+{% from "../components/error-summary/error-summary.njk" import errorSummary with context %}
 
 {% set locale = interpolate(locale, {
     subject: data.popData,


### PR DESCRIPTION
Update of all hardcoded `There is a problem` titles to use the wording associated with the commonLocale. The errorSummary components have had `with context` added to those imports to allow the file access (or context) to what the commonLocale is.