### PR TITLE
SP2-703 Redirect to future goals tab after adding steps

### DIFF
--- a/server/routes/add-steps/AddStepsController.test.ts
+++ b/server/routes/add-steps/AddStepsController.test.ts
@@ -213,10 +213,84 @@ describe('AddStepsController', () => {
       expect(next).not.toHaveBeenCalled()
     })
 
-    it('should save and redirect when action is not "add-step" or "remove-step"', async () => {
+    it('should save and redirect to plan current tab when adding steps during Create Goal', async () => {
+      req.services.sessionService.getReturnLink = jest.fn().mockReturnValue('/change-goal/some-goal-uuid/')
+
       req.body = {
         action: 'save',
         goalStatus: 'ACTIVE',
+        'step-actor-1': 'Test actor',
+        'step-description-1': 'a test step',
+        'step-status-1': StepStatus.NOT_STARTED,
+        'step-actor-2': 'Batman',
+        'step-description-2': 'test',
+        'step-status-2': StepStatus.IN_PROGRESS,
+      }
+      req.params = { uuid: 'some-goal-uuid' }
+
+      const expectedData = {
+        steps: [
+          {
+            description: 'a test step',
+            status: StepStatus.NOT_STARTED,
+            actor: 'Test actor',
+          },
+          {
+            description: 'test',
+            status: StepStatus.IN_PROGRESS,
+            actor: 'Batman',
+          },
+        ],
+      }
+
+      await runMiddlewareChain(controller.post, req, res, next)
+
+      expect(req.services.stepService.saveAllSteps).toHaveBeenCalledWith(expectedData, 'some-goal-uuid')
+      expect(res.redirect).toHaveBeenCalledWith(`${URLs.PLAN_OVERVIEW}?type=current`)
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('should save and redirect to plan future tab when adding steps during Create Goal', async () => {
+      req.services.sessionService.getReturnLink = jest.fn().mockReturnValue('/change-goal/some-goal-uuid/')
+
+      req.body = {
+        action: 'save',
+        goalStatus: 'FUTURE',
+        'step-actor-1': 'Test actor',
+        'step-description-1': 'a test step',
+        'step-status-1': StepStatus.NOT_STARTED,
+        'step-actor-2': 'Batman',
+        'step-description-2': 'test',
+        'step-status-2': StepStatus.IN_PROGRESS,
+      }
+      req.params = { uuid: 'some-goal-uuid' }
+
+      const expectedData = {
+        steps: [
+          {
+            description: 'a test step',
+            status: StepStatus.NOT_STARTED,
+            actor: 'Test actor',
+          },
+          {
+            description: 'test',
+            status: StepStatus.IN_PROGRESS,
+            actor: 'Batman',
+          },
+        ],
+      }
+
+      await runMiddlewareChain(controller.post, req, res, next)
+
+      expect(req.services.stepService.saveAllSteps).toHaveBeenCalledWith(expectedData, 'some-goal-uuid')
+      expect(res.redirect).toHaveBeenCalledWith(`${URLs.PLAN_OVERVIEW}?type=future`)
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('should save and redirect when action is not "add-step" or "remove-step"', async () => {
+      req.body = {
+        action: 'save',
+        goalStatus: 'FUTURE',
         'step-actor-1': 'Test actor',
         'step-description-1': 'a test step',
         'step-status-1': StepStatus.NOT_STARTED,

--- a/server/routes/add-steps/AddStepsController.test.ts
+++ b/server/routes/add-steps/AddStepsController.test.ts
@@ -170,6 +170,7 @@ describe('AddStepsController', () => {
     it('should add a new step and re-render the page', async () => {
       req.body = {
         action: 'add-step',
+        goalStatus: 'ACTIVE',
         'step-actor-1': 'Test actor',
         'step-description-1': 'a test step',
         'step-status-1': StepStatus.NOT_STARTED,
@@ -180,6 +181,7 @@ describe('AddStepsController', () => {
 
       const expectedData = { ...viewData }
       expectedData.data.form = {
+        goalStatus: 'ACTIVE',
         'step-actor-1': 'Test actor',
         'step-description-1': 'a test step',
         'step-status-1': StepStatus.NOT_STARTED,
@@ -214,6 +216,7 @@ describe('AddStepsController', () => {
     it('should save and redirect when action is not "add-step" or "remove-step"', async () => {
       req.body = {
         action: 'save',
+        goalStatus: 'ACTIVE',
         'step-actor-1': 'Test actor',
         'step-description-1': 'a test step',
         'step-status-1': StepStatus.NOT_STARTED,
@@ -293,6 +296,7 @@ describe('AddStepsController', () => {
     it('should call next with an error if saveAllSteps fails', async () => {
       req.body = {
         action: 'save',
+        goalStatus: 'ACTIVE',
         'step-actor-1': 'Batman',
         'step-description-1': 'a test step',
         'step-status-1': StepStatus.NOT_STARTED,

--- a/server/routes/add-steps/AddStepsController.ts
+++ b/server/routes/add-steps/AddStepsController.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Request, Response } from 'express'
 import locale from './locale.json'
 import URLs from '../URLs'
-import { toKebabCase } from '../../utils/utils'
+import { goalStatusToTabName, toKebabCase } from '../../utils/utils'
 import validateRequest from '../../middleware/validationMiddleware'
 import AddStepsPostModel, { StepModel } from './models/AddStepsPostModel'
 import transformRequest from '../../middleware/transformMiddleware'
@@ -78,9 +78,11 @@ export default class AddStepsController {
     try {
       await req.services.stepService.saveAllSteps(goalData, req.params.uuid)
 
+      const type = goalStatusToTabName(req.body.goalStatus)
+
       const link =
         req.services.sessionService.getReturnLink() === `/change-goal/${req.params.uuid}/`
-          ? `${URLs.PLAN_OVERVIEW}?type=current`
+          ? `${URLs.PLAN_OVERVIEW}?type=${type}`
           : req.services.sessionService.getReturnLink()
 
       return res.redirect(link)

--- a/server/views/pages/add-steps.njk
+++ b/server/views/pages/add-steps.njk
@@ -77,9 +77,9 @@
     </div>
 </div>
 
-<form id="create-goal-form" method="POST">
+<form id="add-steps-form" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-    <input type="hidden" id="_areaOfNeed" value="{{ data.areaOfNeed }}"/>
+    <input type="hidden" name="goalStatus" value="{{ data.goal.status }}"/>
     {% set steps = data.form.steps if data.form.steps and data.form.steps.length > 0 else [{}] %}
 
     <button aria-hidden="true" tabindex="-1" value="add-step" type="submit" name="action" class="govuk-visually-hidden">Visually hidden add another step</button>


### PR DESCRIPTION
During the Create Goal flow and you choose to make it a goal for the future and you add steps, the "Add steps" page should redirect you back to the "future goals" tab on the Plan page. 

If the goal has a target date it should redirect you to the "goals for now" tab on the Plan page.