### PR TITLE
SP2-1468 SP2-1469 Updates rendering to match all forms of Plan Agreement.

### DIFF
--- a/server/views/components/summary-card/goal-summary-card.njk
+++ b/server/views/components/summary-card/goal-summary-card.njk
@@ -56,44 +56,44 @@
         </div>
 
         {% if params.goal.steps and params.goal.steps.length > 0 %}
-          {% set completedCount = 0 %}
-          {% for step in params.goal.steps %}
-            {% if step.status == 'COMPLETED' %}
-              {% set completedCount = completedCount + 1 %}
+            {% set completedCount = 0 %}
+            {% for step in params.goal.steps %}
+                {% if step.status == 'COMPLETED' %}
+                    {% set completedCount = completedCount + 1 %}
+                {% endif %}
+            {% endfor %}
+            {% if params.plan.agreementStatus and params.plan.agreementStatus != 'DRAFT' %}
+                <p class="step-counter">
+                    {% if params.goal.steps.length == 1 %}
+                        {{ completedCount }}{{ locale.info.stepsCompletedSingular }}
+                    {% else %}
+                        {{ completedCount }}{{ locale.info.stepsCompletedPlural }}
+                    {% endif %}
+                </p>
+                <details class="govuk-details">
+                    <summary class="govuk-details__summary">
+                        <span class="govuk-details__summary-text">
+                          View steps
+                        </span>
+                    </summary>
             {% endif %}
-          {% endfor %}
-          {% if params.plan.agreementStatus == 'AGREED' %}
-            <p class="step-counter">
-            {% if params.goal.steps.length == 1 %}
-              {{ completedCount }}{{ locale.info.stepsCompletedSingular }}
-            {% else %}
-              {{ completedCount }}{{ locale.info.stepsCompletedPlural }}
-            {% endif %}
-            </p>
-          <details class="govuk-details">
-                <summary class="govuk-details__summary">
-                  <span class="govuk-details__summary-text">
-                    View steps
-                  </span>
-                </summary>
-          {% endif %}
             <div class="{% if params.plan.agreementStatus == 'AGREED' %}govuk-details__text
                         {% elseif params.plan.agreementStatus == 'DRAFT' %}govuk-details__text_inactive
                         {% endif %}">
-              <table class="govuk-table goal-summary-card__steps">
-                      <thead class="govuk-table__head">
+                <table class="govuk-table goal-summary-card__steps">
+                    <thead class="govuk-table__head">
                       <tr class="govuk-table__row">
                           <th scope="col" class="govuk-table__header">{{ locale.stepsList.whoHeader }}</th>
                           <th scope="col" class="govuk-table__header">{{ locale.stepsList.whatHeader }}</th>
                           <th scope="col" class="govuk-table__header">{{ locale.stepsList.statusHeader }}</th>
                       </tr>
                       </thead>
-                    <tbody class="govuk-table__body">
-                    {% for step in params.goal.steps %}
-                      <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">{{ step.actor | replace(" (include who in the step)", "") }}</td>
-                            <td class="govuk-table__cell">{{ step.description }}</td>
-                            <td class="govuk-table__cell">
+                      <tbody class="govuk-table__body">
+                      {% for step in params.goal.steps %}
+                          <tr class="govuk-table__row">
+                              <td class="govuk-table__cell">{{ step.actor | replace(" (include who in the step)", "") }}</td>
+                              <td class="govuk-table__cell">{{ step.description }}</td>
+                              <td class="govuk-table__cell">
                                 {% if step.status =='NOT_STARTED' %}
                                     <strong class="govuk-tag govuk-tag--grey">{{ locale.stepsList.status.notStarted }}</strong>
                                 {% elseif step.status == 'IN_PROGRESS' %}
@@ -105,24 +105,23 @@
                                 {% elseif step.status == 'NO_LONGER_NEEDED' %}
                                     <strong class="govuk-tag govuk-tag--yellow">{{ locale.stepsList.status.noLongerNeeded }}</strong>
                                 {% endif %}
-                            </td>
-                        </tr>
-                    {% endfor %}
-                    </tbody>
-              </table>
-            </div>
-          </details>
-        {% else %}
+                              </td>
+                          </tr>
+                      {% endfor %}
+                      </tbody>
+                  </table>
+              </div>
+              </details>
+          {% else %}
             <div class="goal-summary-card__steps--empty">
                 <strong>{{ locale.stepsList.noStepsAdded }}</strong>
                 {% if params.actions.length > 0 %}
                     <a class="govuk-!-display-none-print" href="/goal/{{ params.goal.uuid }}/add-steps">{{ locale.stepsList.addSteps }}</a>
                 {% endif %}
             </div>
-        {% endif %}
-            <p class="{% if params.plan.agreementStatus == 'DRAFT' %}goal-summary-card__areas-of-need
-                      {% elseif params.plan.agreementStatus == 'AGREED' %}goal-summary-card__areas-of-need_agreed
-                      {% endif %}">
+          {% endif %}
+            <p class="goal-summary-card__areas-of-need
+                {%- if params.plan.agreementStatus and params.plan.agreementStatus !== 'DRAFT' -%}_agreed{%- endif -%}">
                 {{ locale.areaOfNeed.mainAreaOfNeed }}<br>
                 {% if params.goal.relatedAreasOfNeed.length > 0 %}
                     {{ locale.areaOfNeed.relatedAreasOfNeed }}


### PR DESCRIPTION
Both of these bugs exist for the same reason - only the "Yes, I agree" answer during Plan Agreement is taken as agreement. This is incorrect - all forms of agreement count, so this change inverts the logic to check for any value except DRAFT.

I modified some of the whitespace in the area I was changing to make it match the code immediately above it so that it was easier to read - hide the whitespace when reviewing this diff, or click here: https://github.com/ministryofjustice/hmpps-sentence-plan-ui/pull/409/files?diff=split&w=1