### PR TITLE
SP2-1439 Makes error logs clearer around plan IDs

### DIFF
--- a/server/routes/error/ErrorController.ts
+++ b/server/routes/error/ErrorController.ts
@@ -11,7 +11,12 @@ export default class ErrorController {
   constructor(private production = process.env.NODE_ENV === 'production') {}
 
   private errorHandler = async (error: HttpError, req: Request, res: Response, next: NextFunction) => {
-    this.logError(error, req.originalUrl, req.session.plan?.uuid)
+    this.logError(
+      error,
+      req.originalUrl,
+      req.services.sessionService.getPlanUUID(),
+      req.services.sessionService.getPlanVersionNumber(),
+    )
 
     res.locals.stack = this.production ? null : error.stack
     res.status(error.status || 500)
@@ -26,8 +31,11 @@ export default class ErrorController {
     }
   }
 
-  private logError = (error: HttpError, url: string, planUuid: string) => {
-    logger.error(`Error handling request for '${url}', plan UUID '${planUuid}'`, error)
+  private logError = (error: HttpError, url: string, planUuid: string, planVersionNumber: number) => {
+    logger.error(
+      `Error handling request for '${url}', plan UUID '${planUuid}', plan version number '${planVersionNumber}', `,
+      error,
+    )
   }
 
   private handleBadRequestErrors = async (error: HttpError, req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/error/routes.test.ts
+++ b/server/routes/error/routes.test.ts
@@ -9,6 +9,7 @@ import localeUnauthorized from './locale-unauthorized.json'
 import localeForbidden from './locale-forbidden.json'
 import localeBadRequest from './locale-bad-request.json'
 import localeServiceFault from './locale-service-fault.json'
+import testPlan from '../../testutils/data/planData'
 
 const mockGet = jest.fn()
 const mockPost = jest.fn()
@@ -17,6 +18,8 @@ jest.mock('../../services/sessionService', () => {
   return jest.fn().mockImplementation(() => ({
     getSubjectDetails: jest.fn().mockReturnValue(handoverData.subject),
     getOasysReturnUrl: jest.fn().mockReturnValue(handoverData.principal.returnUrl),
+    getPlanUUID: jest.fn().mockReturnValue(testPlan.uuid),
+    getPlanVersionNumber: jest.fn().mockReturnValue(null),
   }))
 })
 


### PR DESCRIPTION
`req.session.plan?.uuid` contains the Plan Version UUID, not the Plan UUID, so remove usage of that value and replace it with Plan UUID and version number.