### PR TITLE
SP2-1403: Fix token expiration check: use '>' instead of '<' to correctly validate expiry

### DIFF
--- a/server/data/hmppsAuthClient.test.ts
+++ b/server/data/hmppsAuthClient.test.ts
@@ -8,8 +8,8 @@ import mockReq from '../testutils/preMadeMocks/mockReq'
 jest.mock('./tokenStore/redisTokenStore')
 
 const username = 'a23ccacf-7160-4431-9b4d-c560be9c9f5c%7CDr.+Benjamin+Runolfsdottir'
-const token = { token: 'token-1', expiresAt: Date.now() - 30 * 1000 }
-const expiredToken = { token: 'token-1', expiresAt: Date.now() + 30 * 1000 }
+const token = { token: 'token-1', expiresAt: Date.now() + 30 * 1000 }
+const expiredToken = { token: 'token-1', expiresAt: Date.now() - 30 * 1000 }
 const tokenFromHmppsAuth = { user_name: 'Bob', access_token: 'token-2', expires_in: '300' }
 
 describe('hmppsAuthClient', () => {

--- a/server/data/hmppsAuthClient.ts
+++ b/server/data/hmppsAuthClient.ts
@@ -43,7 +43,7 @@ export default class HmppsAuthClient {
   }
 
   async getSystemClientToken(): Promise<string> {
-    if (this.getToken()?.expiresAt < Date.now()) {
+    if (this.getToken()?.expiresAt > Date.now()) {
       return this.getToken().token
     }
 


### PR DESCRIPTION
This changes the logic to only generate a new token when the current one is expired. Prior to the change, it looks like we were generating a new token every time when it was valid, but when it was invalid we were passing back the old one which was causing timeout issues to users.