### PR TITLE
SP2-1450 about page aria controls

### DIFF
--- a/integration_tests/e2e/about.cy.ts
+++ b/integration_tests/e2e/about.cy.ts
@@ -29,6 +29,8 @@ describe('Rendering About Person for READ_WRITE user', () => {
         expect(text).to.include('Unpaid work')
         expect(text).to.include('RAR (Rehabilitation activity requirement)')
       })
+
+    cy.checkAccessibility()
   })
 
   it('Should check if the hard-coded entries in Sentence information are displayed correctly', () => {
@@ -285,6 +287,7 @@ describe('Rendering About Person in READ_ONLY', () => {
     cy.get('h2').eq(3).contains('High-scoring areas from the assessment')
     cy.get('[role="button"]').should('have.length', 1)
     cy.get('[role="button"]').eq(0).should('contain', 'Return to OASys')
+    cy.checkAccessibility()
   })
 
   it('Should check there are no links to create goal', () => {

--- a/server/views/components/assessment/_assessment-area.njk
+++ b/server/views/components/assessment/_assessment-area.njk
@@ -1,7 +1,7 @@
 {% from "../../components/need-score/macro.njk" import needsScore %}
 {% from "components/need-score-indicator/macro.njk" import needsScoreIndicator %}
 
-<div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default-{{ loop.index }}">
+<div class="govuk-accordion" data-module="govuk-accordion" id="assessment-accordion-{{ assessmentGroupId }}">
     {% for assessment in formattedAssessments %}
         <div class="govuk-accordion__section" id="{{ assessment.goalRoute }}">
             <div class="govuk-accordion__section-header">
@@ -12,7 +12,7 @@
                     </span>
                 </h3>
                 <div class="govuk-accordion__section-summary govuk-body sp-accordion-tags"
-                     id="accordion-with-summary-sections-summary-{{ loop.index }}">
+                     id="accordion-with-summary-sections-summary-{{ assessment.goalRoute }}-{{ loop.index }}">
                     {% if assessment.isAssessmentSectionComplete and assessment.linkedToHarm === 'YES' %}
                         <span class="moj-badge moj-badge--large moj-badge--purple sp-badge">{{ locale.detail.RoSH }}</span>
                     {% endif %}
@@ -21,7 +21,7 @@
                     {% endif %}
                 </div>
             </div>
-            <div id="accordion-default-content-{{ loop.index }}" class="govuk-accordion__section-content">
+            <div id="assessment-accordion-{{ assessmentGroupId }}-content-{{ loop.index }}" class="govuk-accordion__section-content">
                 {% if assessment.criminogenicNeedMissing %}
                     <p>This information isn't currently available, please check in OASys.</p>
                 {% else %}

--- a/server/views/components/assessment/assessment.njk
+++ b/server/views/components/assessment/assessment.njk
@@ -1,3 +1,3 @@
-{% macro renderAssessment(formattedAssessments, locale, readWrite) %}
+{% macro renderAssessment(assessmentGroupId, formattedAssessments, locale, readWrite) %}
     {%- include "./_assessment-area.njk" -%}
 {% endmacro %}

--- a/server/views/pages/about.njk
+++ b/server/views/pages/about.njk
@@ -115,19 +115,19 @@
           {% if data.formattedAssessmentInfo.areas.incompleteAreas.length > 0 %}
             <h2 class="govuk-heading-m">{{ locale.incompleteAssessment.sectionHeading }}</h2>
             <p class="govuk-body">{{ locale.incompleteAssessment.sectionParagraph }}</p>
-            {{ renderAssessment(data.formattedAssessmentInfo.areas.incompleteAreas, locale, data.readWrite) }}
+            {{ renderAssessment('incompleteAreas', data.formattedAssessmentInfo.areas.incompleteAreas, locale, data.readWrite) }}
           {% endif %}
 
             <h2 class="govuk-heading-m">{{ locale.highScoring.sectionHeading }}</h2>
             {% if data.formattedAssessmentInfo.areas.highScoring.length > 0 %}
-                {{ renderAssessment(data.formattedAssessmentInfo.areas.highScoring, locale, data.readWrite) }}
+                {{ renderAssessment('highScoring', data.formattedAssessmentInfo.areas.highScoring, locale, data.readWrite) }}
             {% else %}
                 <p class="govuk-body">{{ locale.highScoring.sectionEmptyParagraph }}</h2>
             {% endif %}
 
             <h2 class="govuk-heading-m">{{ locale.lowScoring.sectionHeading }}</h2>
             {% if data.formattedAssessmentInfo.areas.lowScoring.length > 0 %}
-                {{ renderAssessment(data.formattedAssessmentInfo.areas.lowScoring, locale, data.readWrite) }}
+                {{ renderAssessment('lowScoring', data.formattedAssessmentInfo.areas.lowScoring, locale, data.readWrite) }}
             {% else %}
                 <p class="govuk-body">{{ locale.lowScoring.sectionEmptyParagraph }}</h2>
             {% endif %}
@@ -135,7 +135,7 @@
             <h2 class="govuk-heading-m">{{ locale.withoutScoring.sectionHeading }}</h2>
             <p id="other-areas-paragraph" class="govuk-body">{{ locale.withoutScoring.sectionParagraph }}</h2>
             {% if data.formattedAssessmentInfo.areas.other.length > 0 %}
-                {{ renderAssessment(data.formattedAssessmentInfo.areas.other, locale, data.readWrite) }}
+                {{ renderAssessment('withoutScoring', data.formattedAssessmentInfo.areas.other, locale, data.readWrite) }}
             {% endif %}
 
         </div>


### PR DESCRIPTION
This resolution was slightly surprising.

The GDS Design System javascript looks for the spans with a class of `govuk-accordion__section-button sp-accordion-header` and inserts a button with the `aria-controls` attribute, which is generated on the fly from the root accordion ID and the current accordion item number.

Because we have four separate accordions on the page I needed to pass through a unique identifier to `renderAssessment` to insert at the root of the accordion and ensure that was also added to the content div so that it would match the generated value of `aria-controls`. This not only made the `aria-controls` and `id` attributes match up, but ensured they were unique.

Exciting!

## Before:

<img width="911" alt="Screenshot 2025-03-05 at 15 29 38" src="https://github.com/user-attachments/assets/10d1e835-55f9-4f13-ab80-6ad3ddc39366" />


## After:

<img width="911" alt="Screenshot 2025-03-05 at 15 31 29" src="https://github.com/user-attachments/assets/35f4fbdc-9b62-4631-bf5f-1aaee3b1ff79" />
