### PR TITLE
SP2-1512 Removing todos which don't need to be done.

### DIFF
--- a/assets/scss/components/_needs-scores.scss
+++ b/assets/scss/components/_needs-scores.scss
@@ -25,7 +25,7 @@ $white-needs-score-background-colour: #ffffff;
 
 .needs-score-label-wrapper {
   width: 10%;
-  // TODO margin-bottom should probably be a relative value based on font-size or line-height rather than a fixed value
+  // the margin bottom is set to 16px to match the height of the border of .needs-score-label__card-pointer
   margin-bottom: 16px;
 }
 

--- a/server/views/pages/plan.njk
+++ b/server/views/pages/plan.njk
@@ -270,11 +270,6 @@
                                         classes: "govuk-!-display-none-print"
                                     }
                                 ] %}
-                                    {#  TODO:SP2-598 {
-                                        href: '#',
-                                        text: locale.goalSummaryCard.actions.removed.addToPlan,
-                                        classes: "govuk-!-display-none-print"
-                                    }#}
                             {% endif %}
                         {% endif %}
                     {% endif %}


### PR DESCRIPTION
The TODO in `plan.njk` comes from a previous design of that page, the change to having a single action on the goal summary card supersedes this TODO.

The TODO in `_needs-scores.scss` was added before I realised that the size offset was directly related to the size of the triangle pointing at the current risk score - I've added a comment to clarify this.