### PR TITLE
Makes pre-commit lint config the same as the lint command config

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "lint-staged": {
     "*.{ts,js,css}": [
       "prettier --write",
-      "eslint --fix"
+      "eslint --fix --max-warnings 0"
     ],
     "*.json": [
       "prettier --write"


### PR DESCRIPTION
The `lint` command runs during the build and is more restrictive than the pre-commit check which means that linting can fail in the server build but pass locally. This makes them behave the same.