### PR TITLE
Modify 'SameSite' cookie attribute to 'Strict'

### DIFF
--- a/server/middleware/setUpWebSession.ts
+++ b/server/middleware/setUpWebSession.ts
@@ -21,7 +21,7 @@ export default function setUpWebSession(): Router {
     session({
       store,
       name: 'hmpps-sentence-plan-ui.session',
-      cookie: { secure: config.https, sameSite: 'lax', maxAge: config.session.expiryMinutes * 60 * 1000 },
+      cookie: { secure: config.https, sameSite: 'Strict', maxAge: config.session.expiryMinutes * 60 * 1000 },
       secret: config.session.secret,
       resave: false, // redis implements touch so shouldn't need this
       saveUninitialized: false,

--- a/server/middleware/setUpWebSession.ts
+++ b/server/middleware/setUpWebSession.ts
@@ -21,7 +21,7 @@ export default function setUpWebSession(): Router {
     session({
       store,
       name: 'hmpps-sentence-plan-ui.session',
-      cookie: { secure: config.https, sameSite: 'Strict', maxAge: config.session.expiryMinutes * 60 * 1000 },
+      cookie: { secure: config.https, sameSite: 'strict', maxAge: config.session.expiryMinutes * 60 * 1000 },
       secret: config.session.secret,
       resave: false, // redis implements touch so shouldn't need this
       saveUninitialized: false,


### PR DESCRIPTION
This is intended to tighten up where the user's session cookie may be sent by the browser to improve security, particularly session-hijack and CSRF threats.