### PR TITLE
Only runs tests related to the changes since `main`. See https://jestjs.io/docs/cli#--changedsince

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-NODE_ENV=dev && node_modules/.bin/lint-staged && npm run build && npm test
+NODE_ENV=dev && node_modules/.bin/lint-staged && npm run build && npm run test:changed

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint . --cache --max-warnings 0",
     "lint-fix": "eslint . --cache --max-warnings 0 --fix",
     "test": "TZ=UTC jest",
+    "test:changed": "TZ=UTC jest --changedSince main",
     "test:ci": "TZ=UTC jest --runInBand",
     "security_audit": "npx audit-ci --config audit-ci.json",
     "int-test": "cypress run --config video=false",


### PR DESCRIPTION
This speeds up the commit process. It doesn't change the CI process, so all unit tests still run there.