### PR TITLE
Regress cookie change for Capita

### DIFF
--- a/server/middleware/setUpWebSession.ts
+++ b/server/middleware/setUpWebSession.ts
@@ -21,7 +21,7 @@ export default function setUpWebSession(): Router {
     session({
       store,
       name: 'hmpps-sentence-plan-ui.session',
-      cookie: { secure: config.https, sameSite: 'strict', maxAge: config.session.expiryMinutes * 60 * 1000 },
+      cookie: { secure: config.https, sameSite: 'lax', maxAge: config.session.expiryMinutes * 60 * 1000 },
       secret: config.session.secret,
       resave: false, // redis implements touch so shouldn't need this
       saveUninitialized: false,


### PR DESCRIPTION
Capita can't seem to access the service when we have SameSite=Strict, so we're regressing this change to unblock their testing, then we'll investigate the issue fully.