### PR TITLE
Pin the version of the action to a specified one

### DIFF
--- a/.github/workflows/pipeline_main.yml
+++ b/.github/workflows/pipeline_main.yml
@@ -79,7 +79,7 @@ jobs:
           pattern: npm_unit_test_artifacts
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b # v2.18.0
         with:
           files: "unit_test_artifacts/**/*.xml"
           check_name: "Unit Test Results"
@@ -91,7 +91,7 @@ jobs:
           pattern: test_results_*
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b # v2.18.0
         with:
           files: "artifacts/**/*.xml"
           check_name: "Cypress Test Results"

--- a/.github/workflows/pipeline_pr.yml
+++ b/.github/workflows/pipeline_pr.yml
@@ -72,7 +72,7 @@ jobs:
           pattern: npm_unit_test_artifacts
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b # v2.18.0
         with:
           files: "unit_test_artifacts/**/*.xml"
           check_name: "Unit Test Results"
@@ -84,7 +84,7 @@ jobs:
           pattern: test_results_*
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b # v2.18.0
         with:
           files: "artifacts/**/*.xml"
           check_name: "Cypress Test Results"

--- a/.github/workflows/pipeline_production.yml
+++ b/.github/workflows/pipeline_production.yml
@@ -80,7 +80,7 @@ jobs:
           pattern: npm_unit_test_artifacts
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b # v2.18.0
         with:
           files: "unit_test_artifacts/**/*.xml"
           check_name: "Unit Test Results"
@@ -92,7 +92,7 @@ jobs:
           pattern: test_results_*
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b # v2.18.0
         with:
           files: "artifacts/**/*.xml"
           check_name: "Cypress Test Results"


### PR DESCRIPTION
To avoid unexpected behaviour, pin the version of the external action to a SHA.