### PR TITLE
Remove eslint excludes

### DIFF
--- a/assets/js/autocomplete/goal-autocomplete.js
+++ b/assets/js/autocomplete/goal-autocomplete.js
@@ -15,11 +15,12 @@ async function getGoalOptionsByAreaOfNeed(areaOfNeed) {
 }
 
 async function initializeGoalInputAutocomplete() {
-  const areaOfNeed = document.querySelector(`#${AREA_OF_NEED_INPUT_ID}`)?.value
+  const areaOfNeedElement = document.querySelector(`#${AREA_OF_NEED_INPUT_ID}`)
+  const areaOfNeed = areaOfNeedElement ? areaOfNeedElement.value : undefined
   const source = await getGoalOptionsByAreaOfNeed(areaOfNeed)
   const wrapperElement = document.querySelector(`.${GOAL_AUTOCOMPLETE_WRAPPER_CLASS}`)
   const inputElement = document.querySelector(`#${GOAL_INPUT_ID}`)
-  const defaultValue = inputElement?.value ?? ''
+  const defaultValue = inputElement ? inputElement.value : ''
   inputElement.remove()
 
   // Update label for the autocomplete input

--- a/assets/js/autocomplete/step-autocomplete.js
+++ b/assets/js/autocomplete/step-autocomplete.js
@@ -15,10 +15,12 @@ async function getStepOptionsByAreaOfNeed(areaOfNeed) {
 }
 
 async function initializeStepInputAutocomplete(inputElement) {
-  const { value, name, parentElement } = inputElement
-  const areaOfNeed = document.querySelector(`#${AREA_OF_NEED_INPUT_ID}`).value
+  const { name, parentElement } = inputElement
+  const areaOfNeedElement = document.querySelector(`#${AREA_OF_NEED_INPUT_ID}`)
+  const areaOfNeed = areaOfNeedElement ? areaOfNeedElement.value : undefined
   const row = name.split('step-description-')[1]
   const source = await getStepOptionsByAreaOfNeed(areaOfNeed)
+  const defaultValue = inputElement ? inputElement.value : ''
   inputElement.remove()
 
   accessibleAutocomplete({
@@ -29,7 +31,7 @@ async function initializeStepInputAutocomplete(inputElement) {
     displayMenu: 'overlay',
     minLength: 2,
     showNoOptionsFound: false,
-    defaultValue: value ?? '',
+    defaultValue,
   })
 
   const element = document.getElementById(`step-description-${row}-autocomplete`)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,7 +2,7 @@ import hmppsConfig from '@ministryofjustice/eslint-config-hmpps'
 
 export default [
   ...hmppsConfig({
-    extraIgnorePaths: ['assets/**'],
+    extraIgnorePaths: ['assets/js/autocomplete/*'],
   }),
   {
     rules: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,9 +1,7 @@
 import hmppsConfig from '@ministryofjustice/eslint-config-hmpps'
 
 export default [
-  ...hmppsConfig({
-    extraIgnorePaths: ['assets/js/autocomplete/*'],
-  }),
+  ...hmppsConfig(),
   {
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',

--- a/package.json
+++ b/package.json
@@ -63,11 +63,12 @@
     ]
   },
   "lint-staged": {
-    "*.{ts,js,css,json}": [
-      "prettier --write"
-    ],
-    "*.ts": [
+    "*.{ts,js,css}": [
+      "prettier --write",
       "eslint --fix --max-warnings 0"
+    ],
+    "*.json": [
+      "prettier --write"
     ]
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -63,12 +63,11 @@
     ]
   },
   "lint-staged": {
-    "*.{ts,js,css}": [
-      "prettier --write",
-      "eslint --fix --max-warnings 0"
-    ],
-    "*.json": [
+    "*.{ts,js,css,json}": [
       "prettier --write"
+    ],
+    "*.ts": [
+      "eslint --fix --max-warnings 0"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
Ensure that the ESLint is able to see the assets directory correctly and a minor update to the lint-staged check to verify correct files. This is required to allow the pre-commit hook checks to enact accordingly if you are editing files under the assets directory.