### PR TITLE
ARN-2786: Fix Cypress tests

### DIFF
--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -18,7 +18,7 @@ declare namespace Cypress {
 
     // API
     addGoalToPlan(planUuid: string, goal: NewGoal): Chainable<Goal>
-    
+
     addStepToGoal(goalUuid: string, step: NewStep): Chainable<Step>
     removeGoalFromPlan(goalUuid: string, note: string): Chainable<Goal>
     agreePlan(planUuid: string): Chainable<Goal>

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -18,6 +18,7 @@ declare namespace Cypress {
 
     // API
     addGoalToPlan(planUuid: string, goal: NewGoal): Chainable<Goal>
+    
     addStepToGoal(goalUuid: string, step: NewStep): Chainable<Step>
     removeGoalFromPlan(goalUuid: string, note: string): Chainable<Goal>
     agreePlan(planUuid: string): Chainable<Goal>

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -18,7 +18,6 @@ declare namespace Cypress {
 
     // API
     addGoalToPlan(planUuid: string, goal: NewGoal): Chainable<Goal>
-
     addStepToGoal(goalUuid: string, step: NewStep): Chainable<Step>
     removeGoalFromPlan(goalUuid: string, note: string): Chainable<Goal>
     agreePlan(planUuid: string): Chainable<Goal>

--- a/integration_tests/support/commands/backend.ts
+++ b/integration_tests/support/commands/backend.ts
@@ -212,8 +212,8 @@ export const removeGoalFromPlan = (goalUuid: string, note: string) => {
   return getApiToken().then(apiToken =>
     cy
       .request({
-        url: `${Cypress.env('SP_API_URL')}/goals/${goalUuid}`,
-        method: 'PATCH',
+        url: `${Cypress.env('SP_API_URL')}/goals/${goalUuid}/remove`,
+        method: 'POST',
         auth: { bearer: apiToken },
         body: goal,
       })


### PR DESCRIPTION
Tests were calling old endpoint, causing failures. This updates them to use the remove endpoint.