### PR TITLE
Hide links displaying in print preview

### DIFF
--- a/server/views/pages/privacy-screen.njk
+++ b/server/views/pages/privacy-screen.njk
@@ -27,7 +27,7 @@
 {% block content %}
     {{ super() }}
 
-    <a class="govuk-back-link" href="{{ data.oasysReturnUrl }}">{{ locale.common.backLink.text }}</a>
+    <a class="govuk-back-link govuk-!-display-none-print" href="{{ data.oasysReturnUrl }}">{{ locale.common.backLink.text }}</a>
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">

--- a/server/views/partials/feedback.njk
+++ b/server/views/partials/feedback.njk
@@ -1,7 +1,7 @@
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 
 {% if feedbackUrl %}
-  <div class="govuk-grid-row user-feedback">
+  <div class="govuk-grid-row user-feedback govuk-!-display-none-print">
     <div class="govuk-grid-column-full">
       {{ govukPhaseBanner({
         tag: {


### PR DESCRIPTION
The PR hides some links which were displaying in print preview. They should be hidden.

- back link in privacy declaration page
- Feedback link