### PR TITLE
ACE-765-Update sign-in guidance and add Oasys homepage link on 401 page

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
       OASTUB_URL: 'http://localhost:7072',
       FEEDBACK_URL: 'http://localhost:9092/',
       MPOP_URL: 'http://localhost:9092',
+      OASYS_URL: 'http://localhost:7072'
     },
     viewportWidth: 1000, // Default value: 1280
     viewportHeight: 660, // Default value: 720

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -48,7 +48,7 @@ export default defineConfig({
       OASTUB_URL: 'http://localhost:7072',
       FEEDBACK_URL: 'http://localhost:9092/',
       MPOP_URL: 'http://localhost:9092',
-      OASYS_URL: 'http://localhost:7072'
+      OASYS_URL: 'http://localhost:7072',
     },
     viewportWidth: 1000, // Default value: 1280
     viewportHeight: 660, // Default value: 720

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -184,6 +184,7 @@ services:
       FEEDBACK_URL: http://localhost:9092
       DELIUS_API_BASE_URL: http://delius:8080
       MPOP_URL: http://localhost:9092
+      OASYS_URL: http://localhost:7072
 
   san-ui:
     image: ghcr.io/ministryofjustice/hmpps-strengths-based-needs-assessments-ui:latest

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -12,6 +12,7 @@ generic-service:
     SENTENCE_PLAN_API_URL: "https://sentence-plan-api-dev.hmpps.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     HMPPS_ARNS_HANDOVER_URL: "https://arns-handover-service-dev.hmpps.service.justice.gov.uk"
+    OASYS_BASE_URL: "https://arns-oastub-dev.hmpps.service.justice.gov.uk"
     MANAGE_USERS_API_URL: "https://manage-users-api-dev.hmpps.service.justice.gov.uk"
     COORDINATOR_API_URL: "https://arns-coordinator-api-dev.hmpps.service.justice.gov.uk"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"

--- a/helm_deploy/values-pr.yaml
+++ b/helm_deploy/values-pr.yaml
@@ -13,6 +13,7 @@ generic-service:
     SENTENCE_PLAN_API_URL: "https://sentence-plan-api-dev.hmpps.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     HMPPS_ARNS_HANDOVER_URL: "https://arns-handover-service-dev.hmpps.service.justice.gov.uk"
+    OASYS_BASE_URL: "https://arns-oastub-dev.hmpps.service.justice.gov.uk"
     MANAGE_USERS_API_URL: "https://manage-users-api-dev.hmpps.service.justice.gov.uk"
     COORDINATOR_API_URL: "https://arns-coordinator-api-dev.hmpps.service.justice.gov.uk"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -12,6 +12,7 @@ generic-service:
     SENTENCE_PLAN_API_URL: "https://sentence-plan-api-preprod.hmpps.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
     HMPPS_ARNS_HANDOVER_URL: "https://arns-handover-service-preprod.hmpps.service.justice.gov.uk"
+    OASYS_BASE_URL: "https://pp.oasys.service.justice.gov.uk"
     MANAGE_USERS_API_URL: "https://manage-users-api-preprod.hmpps.service.justice.gov.uk"
     COORDINATOR_API_URL: "https://arns-coordinator-api-preprod.hmpps.service.justice.gov.uk"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-preprod.prison.service.justice.gov.uk"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -12,6 +12,7 @@ generic-service:
     SENTENCE_PLAN_API_URL: "https://sentence-plan-api.hmpps.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
     HMPPS_ARNS_HANDOVER_URL: "https://arns-handover-service.hmpps.service.justice.gov.uk"
+    OASYS_BASE_URL: "https://oasys.service.justice.gov.uk"
     MANAGE_USERS_API_URL: "https://manage-users-api.hmpps.service.justice.gov.uk"
     COORDINATOR_API_URL: "https://arns-coordinator-api.hmpps.service.justice.gov.uk"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api.prison.service.justice.gov.uk"

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -12,6 +12,7 @@ generic-service:
     SENTENCE_PLAN_API_URL: "https://sentence-plan-api-test.hmpps.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     HMPPS_ARNS_HANDOVER_URL: "https://arns-handover-service-test.hmpps.service.justice.gov.uk"
+    OASYS_BASE_URL: "https://arns-oastub-test.hmpps.service.justice.gov.uk"
     MANAGE_USERS_API_URL: "https://manage-users-api-dev.hmpps.service.justice.gov.uk"
     COORDINATOR_API_URL: "https://arns-coordinator-api-test.hmpps.service.justice.gov.uk"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"

--- a/integration_tests/e2e/e2e-tests/plan-overview-noauth.cy.ts
+++ b/integration_tests/e2e/e2e-tests/plan-overview-noauth.cy.ts
@@ -2,15 +2,7 @@ describe('Attempt to access without having logged in', () => {
   it('Shows the 401 error page', () => {
     cy.visit('/plan', { failOnStatusCode: false })
     cy.get('.govuk-heading-l').should('have.text', 'You need to sign in to use this service')
-    cy.contains('a', 'the OASys homepage').should(
-      'have.attr',
-      'href',
-      Cypress.env('OASYS_URL'),
-      )
-    cy.contains('a', 'Manage people on probation').should(
-      'have.attr',
-      'href',
-      Cypress.env('MPOP_URL'),
-    )
+    cy.contains('a', 'the OASys homepage').should('have.attr', 'href', Cypress.env('OASYS_URL'))
+    cy.contains('a', 'Manage people on probation').should('have.attr', 'href', Cypress.env('MPOP_URL'))
   })
 })

--- a/integration_tests/e2e/e2e-tests/plan-overview-noauth.cy.ts
+++ b/integration_tests/e2e/e2e-tests/plan-overview-noauth.cy.ts
@@ -2,8 +2,12 @@ describe('Attempt to access without having logged in', () => {
   it('Shows the 401 error page', () => {
     cy.visit('/plan', { failOnStatusCode: false })
     cy.get('.govuk-heading-l').should('have.text', 'You need to sign in to use this service')
-    cy.contains('li', 'Go to the OASys homepage to sign-in')
-    cy.contains('a', 'Go to the Manage People on Probation service').should(
+    cy.contains('a', 'the OASys homepage').should(
+      'have.attr',
+      'href',
+      Cypress.env('OASYS_URL'),
+      )
+    cy.contains('a', 'Manage people on probation').should(
       'have.attr',
       'href',
       Cypress.env('MPOP_URL'),

--- a/integration_tests/e2e/e2e-tests/session-timeout.cy.ts
+++ b/integration_tests/e2e/e2e-tests/session-timeout.cy.ts
@@ -43,22 +43,18 @@ describe('Session timeout', () => {
       cy.get('#hmrc-timeout-sign-out-link').click()
       cy.url().should('include', '/plan')
       cy.get('h1').should('exist').contains('You need to sign in to use this service')
-      cy.get('p')
-        .contains('This could be because you’ve used a bookmarked link, or your session has expired due to inactivity.')
-        .should('exist')
-      cy.get('li').contains('Go to the OASys homepage to sign-in').should('exist')
-      cy.get('li').contains('Go to the Manage People on Probation service to sign-in').should('exist')
+      cy.get('p').contains('You can sign in from:').should('exist')
+      cy.get('li').contains('the OASys homepage').should('exist')
+      cy.get('li').contains('Manage people on probation').should('exist')
     })
 
     it('Should destroy the session when session has expired', () => {
       cy.clock().tick(10 * 60 * 1000) // 10 minutes in milliseconds.
       cy.url().should('include', '/plan')
       cy.get('h1').should('exist').contains('You need to sign in to use this service')
-      cy.get('p')
-        .contains('This could be because you’ve used a bookmarked link, or your session has expired due to inactivity.')
-        .should('exist')
-      cy.get('li').contains('Go to the OASys homepage to sign-in').should('exist')
-      cy.get('li').contains('Go to the Manage People on Probation service to sign-in').should('exist')
+      cy.get('p').contains('You can sign in from:').should('exist')
+      cy.get('li').contains('the OASys homepage').should('exist')
+      cy.get('li').contains('Manage people on probation').should('exist')
     })
 
     it('Should display the session timeout modal again if a user hits inactivity of 50 minutes after continuing a session', () => {
@@ -80,11 +76,9 @@ describe('Session timeout', () => {
     it('Should render the 401 page', () => {
       cy.visit('/plan', { failOnStatusCode: false })
       cy.get('h1').should('exist').contains('You need to sign in to use this service')
-      cy.get('p')
-        .contains('This could be because you’ve used a bookmarked link, or your session has expired due to inactivity.')
-        .should('exist')
-      cy.get('li').contains('Go to the OASys homepage to sign-in').should('exist')
-      cy.get('li').contains('Go to the Manage People on Probation service to sign-in').should('exist')
+      cy.get('p').contains('You can sign in from:').should('exist')
+      cy.get('li').contains('the OASys homepage').should('exist')
+      cy.get('li').contains('Manage people on probation').should('exist')
     })
   })
 })

--- a/server/config.ts
+++ b/server/config.ts
@@ -136,6 +136,7 @@ export default {
     audit: auditConfig(),
   },
   domain: get('INGRESS_URL', 'http://localhost:3001', requiredInProduction),
+  oasysUrl: get('OASYS_URL', 'http://localhost:7072', requiredInProduction),
   environmentName: get('ENVIRONMENT_NAME', ''),
   deploymentName: get('DEPLOYMENT_NAME', ''),
   feedbackUrl: get('FEEDBACK_URL', null),

--- a/server/middleware/nunjucks/nunjucksSetup.ts
+++ b/server/middleware/nunjucks/nunjucksSetup.ts
@@ -21,6 +21,7 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
   app.locals.environmentNameColour = config.environmentName === 'PRE-PRODUCTION' ? 'govuk-tag--green' : ''
   app.locals.sessionExpiryTime = config.session.expiryMinutes
   app.locals.managePeopleOnProbationUrl = config.managePeopleOnProbationUrl
+  app.locals.oasysUrl = config.oasysUrl
 
   // Cachebusting version string
   if (production) {

--- a/server/routes/error/locale-unauthorized.json
+++ b/server/routes/error/locale-unauthorized.json
@@ -7,11 +7,11 @@
       "title": "You need to sign in to use this service"
     },
     "suggestions": [
-      "This could be because you’ve used a bookmarked link, or your session has expired due to inactivity."
+      "You can sign in from:"
     ],
     "resolution": {
-      "oasys": "Go to the OASys homepage to sign-in",
-      "auth": "<a href='{{ managePeopleOnProbationUrl }}'>Go to the Manage People on Probation service</a> to sign-in"
+      "oasys": "<a href='{{ oasysUrl }}'>the OASys homepage</a>",
+      "auth": "<a href='{{ managePeopleOnProbationUrl }}'>Manage people on probation</a>"
     }
   }
 }

--- a/server/views/pages/error.njk
+++ b/server/views/pages/error.njk
@@ -2,7 +2,8 @@
 
 {% set locale = interpolate(locale, {
   systemReturnUrl: data.systemReturnUrl,
-  managePeopleOnProbationUrl: managePeopleOnProbationUrl
+  managePeopleOnProbationUrl: managePeopleOnProbationUrl,
+  oasysUrl: oasysUrl
 }) %}
 
 {% set resolutionMessage %}


### PR DESCRIPTION
- Add actionable Oasys Homepage link on the Sentence Planning "You need to sign in" 401 page 
- Update messaging 
- Add Cypress env variables and e2e assertions for the new link

<img width="999" height="354" alt="new_401_messaging" src="https://github.com/user-attachments/assets/820f8a5f-f7a5-4778-81e7-5fb024794e51" />
