### PR TITLE
ACE-767 Fixes space between header and H1 on error pages

### DIFF
--- a/server/views/pages/error.njk
+++ b/server/views/pages/error.njk
@@ -32,7 +32,7 @@
 {% block content %}
   {{ super() }}
 
-  <div class="govuk-grid-row govuk-!-margin-top-4">
+  <div class="govuk-grid-row govuk-!-margin-top-8">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ locale.mainHeading.title }}</h1>
       {% for suggestion in locale.suggestions %}

--- a/server/views/pages/not-found.njk
+++ b/server/views/pages/not-found.njk
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block content %}
-  <div class="govuk-grid-row">
+  <div class="govuk-grid-row govuk-!-margin-top-8">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ locale.mainHeading.title }}</h1>
       {% for suggestion in locale.suggestions %}


### PR DESCRIPTION
Jira Ticket - https://dsdmoj.atlassian.net/browse/ACE-767

- Fixed space between header and H1 on error pages

**Page Not Found - 404**

<img width="1669" height="604" alt="error404_page_not_found" src="https://github.com/user-attachments/assets/24ab6644-2667-478e-b7fe-97d4a98fcdcb" />

**Unauthorised Error - 401**

<img width="1636" height="550" alt="error401_unauthorised" src="https://github.com/user-attachments/assets/338c5b4d-c1ba-4b61-8939-88ccfaeb870e" />




