### PR TITLE
SP2-1224-fix-date-parsing

### DIFF
--- a/server/middleware/nunjucks/helpers.test.ts
+++ b/server/middleware/nunjucks/helpers.test.ts
@@ -1,0 +1,28 @@
+import { formatDate } from './helpers'
+
+describe('formatDate', () => {
+  it('returns ISO format for valid date with "iso" format', () => {
+    expect(formatDate('1990-01-01', 'iso')).toBe('1990-01-01')
+  })
+
+  it('returns simple format for valid date with "simple" format', () => {
+    expect(formatDate('1990-01-01', 'simple')).toBe('1 January 1990')
+  })
+
+  it('returns simple format for valid date with "simple" format', () => {
+    expect(formatDate(null, 'simple')).toBe('')
+  })
+
+  it('returns empty string for invalid date', () => {
+    expect(formatDate('invalid-date', 'iso')).toBe('')
+  })
+
+  it('returns empty string for empty date string', () => {
+    expect(formatDate('', 'iso')).toBe('')
+  })
+
+  it('returns simple format for valid date with default format', () => {
+    // @ts-expect-error we expect a linting error here, the second argument is intentionally invalid
+    expect(formatDate('1990-01-01', 'unknown')).toBe('1 January 1990')
+  })
+})

--- a/server/middleware/nunjucks/helpers.ts
+++ b/server/middleware/nunjucks/helpers.ts
@@ -56,6 +56,10 @@ export const toFormattedError = (errors: any, locale: any, fieldName: string) =>
 }
 
 export const formatDate = (date: string, format: 'iso' | 'simple') => {
+  if (!date) {
+    return ''
+  }
+
   const parsedDate = new Date(date)
 
   if (Number.isNaN(parsedDate.getTime())) {


### PR DESCRIPTION
Outputs blank datestamp rather than epoch date when incoming date data is missing.