### PR TITLE
SP2-1651: Hide dropdown and about page links

### DIFF
--- a/integration_tests/e2e/e2e-tests/create-goal.cy.ts
+++ b/integration_tests/e2e/e2e-tests/create-goal.cy.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker'
 import CreateGoal from '../../pages/create-goal'
 import { AccessMode } from '../../../server/@types/SessionType'
+import { handleDataPrivacyScreen } from '../../support/commands/privacyScreen'
 
 describe('Create a new Goal', () => {
   const createGoalPage = new CreateGoal()
@@ -149,6 +150,29 @@ describe('Create a new Goal', () => {
           )
         })
       cy.checkAccessibility()
+    })
+  })
+
+  describe('Assessment information (HMPPS Auth user)', () => {
+    const randomCRN = `X${Math.floor(100000 + Math.random() * 900000)}`
+
+    beforeEach(() => {
+      cy.createSentencePlan().then(planDetails => {
+        cy.openSentencePlanAuth(planDetails.oasysAssessmentPk, {
+          planUuid: planDetails.plan.uuid,
+          crn: randomCRN,
+          username: 'AUTH_ADM',
+        })
+
+        handleDataPrivacyScreen()
+      })
+    })
+
+    it('Hides show assessment info details dropdown when using HMPPS Auth', () => {
+      cy.visit('/create-goal/accommodation')
+
+      cy.get('.govuk-details__summary-text').should('not.exist')
+      cy.get('.govuk-details__text').should('not.exist')
     })
   })
 })

--- a/integration_tests/e2e/e2e-tests/plan-overview-auth.cy.ts
+++ b/integration_tests/e2e/e2e-tests/plan-overview-auth.cy.ts
@@ -1,5 +1,5 @@
 import PlanOverview from '../../pages/plan-overview'
-import URLs from '../../../server/routes/URLs'
+import { handleDataPrivacyScreen } from '../../support/commands/privacyScreen'
 
 const setupPlan = () => {
   const randomCRN = `X${Math.floor(100000 + Math.random() * 900000)}`
@@ -11,13 +11,7 @@ const setupPlan = () => {
       username: 'AUTH_ADM',
     })
 
-    cy.url().then(url => {
-      if (url.includes(URLs.DATA_PRIVACY)) {
-        cy.get('.govuk-checkboxes').click()
-        cy.get('.govuk-button').click()
-        cy.url().should('include', URLs.PLAN_OVERVIEW)
-      }
-    })
+    handleDataPrivacyScreen()
   })
 }
 

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -19,6 +19,7 @@ declare namespace Cypress {
       options?: { accessMode?: string; planUuid?: string; planVersion?: number; crn?: string; username?: string },
     ): Chainable<T>
     createSentencePlan(): Chainable<T>
+    handleDataPrivacyScreen(): Chainable<T>
 
     // API
     addGoalToPlan(planUuid: string, goal: NewGoal): Chainable<Goal>

--- a/integration_tests/support/commands/privacyScreen.ts
+++ b/integration_tests/support/commands/privacyScreen.ts
@@ -1,0 +1,12 @@
+import URLs from '../../../server/routes/URLs'
+
+// eslint-disable-next-line import/prefer-default-export
+export const handleDataPrivacyScreen = () => {
+  cy.url().then(url => {
+    if (url.includes(URLs.DATA_PRIVACY)) {
+      cy.get('.govuk-checkboxes').click()
+      cy.get('.govuk-button').click()
+      cy.url().should('include', URLs.PLAN_OVERVIEW)
+    }
+  })
+}

--- a/integration_tests/support/index.ts
+++ b/integration_tests/support/index.ts
@@ -18,6 +18,7 @@ import {
   checkBothPreviousVersionsTables,
   hasPreviousVersionsPageLink,
 } from './commands/previousVersions'
+import { handleDataPrivacyScreen } from './commands/privacyScreen'
 
 compareSnapshotCommand()
 
@@ -25,6 +26,7 @@ compareSnapshotCommand()
 Cypress.Commands.add('openSentencePlan', openSentencePlan)
 Cypress.Commands.add('openSentencePlanAuth', openSentencePlanAuth)
 Cypress.Commands.add('createSentencePlan', createSentencePlan)
+Cypress.Commands.add('handleDataPrivacyScreen', handleDataPrivacyScreen)
 
 // API
 Cypress.Commands.add('addGoalToPlan', addGoalToPlan)

--- a/server/routes/aboutPerson/AboutPersonController.test.ts
+++ b/server/routes/aboutPerson/AboutPersonController.test.ts
@@ -246,19 +246,6 @@ describe('AboutPersonController - assessment incomplete', () => {
       expect(res.render).toHaveBeenCalledWith('pages/about', expectedPayload)
       expect(req.services.auditService.send).toHaveBeenCalledWith(AuditEvent.VIEW_ABOUT_PAGE)
     })
-
-    it('redirects HMPPS Auth users from the /about page to the /plan page', async () => {
-      const req = mockReq()
-      req.services.sessionService.getPrincipalDetails = jest.fn().mockReturnValue({ authType: AuthType.HMPPS_AUTH})
-      const res = mockRes()
-      const next = jest.fn()
-
-      await controller.get(req, res, next)
-
-      expect(res.redirect).toHaveBeenCalledWith(URLs.PLAN_OVERVIEW)
-      expect(next).not.toHaveBeenCalled()
-
-    })
   })
 
   describe('Get About Person READ_ONLY', () => {
@@ -285,6 +272,18 @@ describe('AboutPersonController - assessment incomplete', () => {
 
       expect(res.render).toHaveBeenCalledWith('pages/about', expectedPayload)
       expect(req.services.auditService.send).toHaveBeenCalledWith(AuditEvent.VIEW_ABOUT_PAGE)
+    })
+  })
+
+  describe('About person controller - handle redirect', () => {
+    it('redirects HMPPS Auth users from the /about page to the /plan page', async () => {
+      req.services.sessionService.getPrincipalDetails = jest.fn().mockReturnValue({ authType: AuthType.HMPPS_AUTH })
+      const next = jest.fn()
+
+      await controller.get(req, res, next)
+
+      expect(res.redirect).toHaveBeenCalledWith(URLs.PLAN_OVERVIEW)
+      expect(next).not.toHaveBeenCalled()
     })
   })
 })

--- a/server/routes/aboutPerson/AboutPersonController.test.ts
+++ b/server/routes/aboutPerson/AboutPersonController.test.ts
@@ -16,7 +16,8 @@ import { FormattedAssessment } from '../../@types/Assessment'
 
 import { formatAssessmentData } from '../../utils/assessmentUtils'
 import { AuditEvent } from '../../services/auditService'
-import { AccessMode } from '../../@types/SessionType'
+import { AccessMode, AuthType } from '../../@types/SessionType'
+import URLs from '../URLs'
 
 const systemReturnUrl = 'https://oasys.return.url'
 
@@ -244,6 +245,19 @@ describe('AboutPersonController - assessment incomplete', () => {
 
       expect(res.render).toHaveBeenCalledWith('pages/about', expectedPayload)
       expect(req.services.auditService.send).toHaveBeenCalledWith(AuditEvent.VIEW_ABOUT_PAGE)
+    })
+
+    it('redirects HMPPS Auth users from the /about page to the /plan page', async () => {
+      const req = mockReq()
+      req.services.sessionService.getPrincipalDetails = jest.fn().mockReturnValue({ authType: AuthType.HMPPS_AUTH})
+      const res = mockRes()
+      const next = jest.fn()
+
+      await controller.get(req, res, next)
+
+      expect(res.redirect).toHaveBeenCalledWith(URLs.PLAN_OVERVIEW)
+      expect(next).not.toHaveBeenCalled()
+
     })
   })
 

--- a/server/routes/aboutPerson/AboutPersonController.ts
+++ b/server/routes/aboutPerson/AboutPersonController.ts
@@ -5,6 +5,8 @@ import { formatAssessmentData } from '../../utils/assessmentUtils'
 import { HttpError } from '../../utils/HttpError'
 import { AuditEvent } from '../../services/auditService'
 import { AccessMode } from '../../@types/SessionType'
+import URLS from '../URLs'
+import { AuthType } from '../../@types/SessionType'
 
 export default class AboutPersonController {
   constructor() {}
@@ -12,6 +14,12 @@ export default class AboutPersonController {
   get = async (req: Request, res: Response, next: NextFunction) => {
     let { errors } = req
     try {
+      // if the user is authenticated via HMPPS Auth, redirect to the plan overview page
+      const authType = req.services.sessionService.getPrincipalDetails()?.authType
+      if (authType === AuthType.HMPPS_AUTH){
+        return res.redirect(URLS.PLAN_OVERVIEW)
+      }
+
       const planUuid = req.services.sessionService.getPlanUUID()
       const popData = req.services.sessionService.getSubjectDetails()
       const systemReturnUrl = req.services.sessionService.getSystemReturnUrl()

--- a/server/routes/aboutPerson/AboutPersonController.ts
+++ b/server/routes/aboutPerson/AboutPersonController.ts
@@ -4,9 +4,8 @@ import { areaConfigs } from '../../utils/assessmentAreaConfig.json'
 import { formatAssessmentData } from '../../utils/assessmentUtils'
 import { HttpError } from '../../utils/HttpError'
 import { AuditEvent } from '../../services/auditService'
-import { AccessMode } from '../../@types/SessionType'
+import { AccessMode, AuthType } from '../../@types/SessionType'
 import URLS from '../URLs'
-import { AuthType } from '../../@types/SessionType'
 
 export default class AboutPersonController {
   constructor() {}
@@ -16,7 +15,7 @@ export default class AboutPersonController {
     try {
       // if the user is authenticated via HMPPS Auth, redirect to the plan overview page
       const authType = req.services.sessionService.getPrincipalDetails()?.authType
-      if (authType === AuthType.HMPPS_AUTH){
+      if (authType === AuthType.HMPPS_AUTH) {
         return res.redirect(URLS.PLAN_OVERVIEW)
       }
 

--- a/server/views/components/assessment/area-assessment-summary.njk
+++ b/server/views/components/assessment/area-assessment-summary.njk
@@ -2,7 +2,8 @@
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% macro assessmentInformationForArea(assessmentDetailsForArea, locale) %}
-<details class="govuk-details">
+  {% if user.authType == 'OASYS' %}
+  <details class="govuk-details">
     <summary class="govuk-details__summary">
         <span class="govuk-details__summary-text">
             {{ locale.common.assessmentInfo.detailsSummary }}
@@ -11,8 +12,10 @@
     <div class="govuk-details__text">
         {{ renderAreaAssessmentSummary(assessmentDetailsForArea, locale) }}
     </div>
-</details>
+  </details>
+  {% endif %}
 {% endmacro %}
+
 
 {% macro renderAreaAssessmentSummary(assessmentDetailsForArea, locale) %}
     {%- include "./_area-assessment-summary.njk" -%}

--- a/server/views/pages/add-steps.njk
+++ b/server/views/pages/add-steps.njk
@@ -7,7 +7,7 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "moj/components/side-navigation/macro.njk" import mojSideNavigation %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "../components/assessment/area-assessment-summary.njk" import assessmentInformationForArea %}
+{% from "../components/assessment/area-assessment-summary.njk" import assessmentInformationForArea with context %}
 
 {% set locale = interpolate(locale, {
     goal: data.goal

--- a/server/views/pages/change-goal.njk
+++ b/server/views/pages/change-goal.njk
@@ -7,7 +7,7 @@
 {% from "../components/error-summary/error-summary.njk" import errorSummary with context %}
 {% from "moj/components/date-picker/macro.njk" import mojDatePicker %}
 {% from "moj/components/side-navigation/macro.njk" import mojSideNavigation %}
-{% from "../components/assessment/area-assessment-summary.njk" import assessmentInformationForArea %}
+{% from "../components/assessment/area-assessment-summary.njk" import assessmentInformationForArea with context %}
 
 {% set locale = interpolate(locale, {
     areaOfNeed: data.selectedAreaOfNeed.name,

--- a/server/views/pages/create-goal.njk
+++ b/server/views/pages/create-goal.njk
@@ -9,7 +9,6 @@
 {% from "../components/error-summary/error-summary.njk" import errorSummary with context %}
 {% from "../components/assessment/area-assessment-summary.njk" import assessmentInformationForArea with context %}
 
-
 {% set locale = interpolate(locale, {
     areaOfNeed: data.selectedAreaOfNeed.name,
     dateOptions: {

--- a/server/views/pages/create-goal.njk
+++ b/server/views/pages/create-goal.njk
@@ -7,7 +7,8 @@
 {% from "moj/components/side-navigation/macro.njk" import mojSideNavigation %}
 {% from "moj/components/date-picker/macro.njk" import mojDatePicker %}
 {% from "../components/error-summary/error-summary.njk" import errorSummary with context %}
-{% from "../components/assessment/area-assessment-summary.njk" import assessmentInformationForArea %}
+{% from "../components/assessment/area-assessment-summary.njk" import assessmentInformationForArea with context %}
+
 
 {% set locale = interpolate(locale, {
     areaOfNeed: data.selectedAreaOfNeed.name,


### PR DESCRIPTION
JIRA Ticket: https://dsdmoj.atlassian.net/browse/SP2-1651

- Hide the 'View information from {name} account' dropdown when the user is not an OASys user
- Re-directs the user to the /plan overview if they try and navigate to the /about URL when the user is not an OASys user
- Refactored logic for handling the data privacy screen within Cypress tests into a reusable custom Cypress command