### PR TITLE
SP2-1685 Add SAN handover e2e test

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -55,6 +55,7 @@ export default defineConfig({
       SAN_API_URL: 'http://localhost:8080',
       COORDINATOR_API_URL: 'http://localhost:8070',
       OASTUB_URL: 'http://localhost:7072',
+      OASYS_UI_URL: 'http://localhost:7072',
       FEEDBACK_URL: 'http://localhost:9092/',
       MPOP_URL: 'http://localhost:9092',
       OASYS_URL: 'http://localhost:7072',

--- a/integration_tests/e2e/e2e-tests/load-san.cy.ts
+++ b/integration_tests/e2e/e2e-tests/load-san.cy.ts
@@ -1,11 +1,19 @@
-import PlanOverview from '../../pages/plan-overview'
+import { AccessMode } from '../../../server/@types/SessionType'
 
 describe('View SAN for READ_WRITE user', () => {
-  beforeEach(() => {
-    cy.createAssessment().enterAssessment()
-  })
+  let firstUserOasysPk = ''
 
   it('Loads initial SAN page', () => {
+    cy.createAssessment().then(() => {
+      firstUserOasysPk = Cypress.env('last_assessment').oasysAssessmentPk
+      cy.enterAssessment(AccessMode.READ_WRITE, { oasysAssessmentPk: firstUserOasysPk })
+    })
+
     cy.visit('http://localhost:3000/start')
+
+    cy.createSentencePlan().then(planDetails => {
+      cy.wrap(planDetails).as('plan')
+      cy.openSentencePlan(planDetails.oasysAssessmentPk)
+    })
   })
 })

--- a/integration_tests/e2e/e2e-tests/load-san.cy.ts
+++ b/integration_tests/e2e/e2e-tests/load-san.cy.ts
@@ -1,0 +1,11 @@
+import PlanOverview from '../../pages/plan-overview'
+
+describe('View SAN for READ_WRITE user', () => {
+  beforeEach(() => {
+    cy.createAssessment().enterAssessment()
+  })
+
+  it('Loads initial SAN page', () => {
+    cy.visit('http://localhost:3000/start')
+  })
+})

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -21,6 +21,10 @@ declare namespace Cypress {
     createSentencePlan(): Chainable<T>
     handleDataPrivacyScreen(): Chainable<T>
 
+    // SAN handover session check when viewing previous version
+    createAssessment(): Chainable<T>
+    enterAssessment(): Chainable<T>
+
     // API
     addGoalToPlan(planUuid: string, goal: NewGoal): Chainable<Goal>
     addStepToGoal(goalUuid: string, step: NewStep): Chainable<Step>

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -22,8 +22,12 @@ declare namespace Cypress {
     handleDataPrivacyScreen(): Chainable<T>
 
     // SAN handover session check when viewing previous version
-    createAssessment(): Chainable<T>
-    enterAssessment(): Chainable<T>
+    createAssessment(data?: { oasysPk?: string }): Chainable<T>
+    enterAssessment(
+      accessMode?: AccessMode,
+      assessmentContextOverride?: AssessmentContext,
+      completePrivacyDeclaration?: boolean,
+    ): Chainable
 
     // API
     addGoalToPlan(planUuid: string, goal: NewGoal): Chainable<Goal>

--- a/integration_tests/support/commands/backend.ts
+++ b/integration_tests/support/commands/backend.ts
@@ -153,7 +153,7 @@ export const openSentencePlan = (
   return cy.visit('/')
 }
 
-export const openSentencePlanAuth = (
+export const openSentencePlanHmppsAuth = (
   oasysAssessmentPk: string,
   options?: { accessMode?: string; planUuid?: string; planVersion?: number; crn?: string; username?: string },
 ) => {

--- a/integration_tests/support/commands/backendSan.ts
+++ b/integration_tests/support/commands/backendSan.ts
@@ -1,0 +1,156 @@
+import handoverData from '../../../server/testutils/data/handoverData'
+import { AccessMode } from '../../../server/@types/SessionType'
+
+/**
+ * This file is a bit fragile. Most of it is a copy of the contents of cypress/support/commands/api.ts in the san-ui
+ * repository.
+ */
+
+export interface AssessmentContext {
+  assessmentId?: string
+  assessmentVersion?: number
+  oasysAssessmentPk?: string
+  sexuallyMotivatedOffenceHistory?: string
+}
+
+export const env = (key: string) => Cypress.env()[key]
+
+const previous = []
+
+export const uuid = () => {
+  let v: string
+  do {
+    v = Math.random().toString().substring(2, 9)
+  } while (previous.includes(v))
+
+  previous.push(v)
+  return v
+}
+
+const oasysUser = {
+  id: uuid().substring(0, 30),
+  name: 'Cypress User',
+}
+
+const getApiToken = () => {
+  const apiToken = Cypress.env('API_TOKEN')
+
+  if (apiToken && apiToken.expiresAt > Date.now() + 2000) {
+    return cy.wrap(apiToken.accessToken).then(token => token)
+  }
+
+  return cy
+    .request({
+      url: `${env('HMPPS_AUTH_URL')}/auth/oauth/token?grant_type=client_credentials`,
+      method: 'POST',
+      form: true,
+      auth: {
+        user: env('CLIENT_ID'),
+        pass: env('CLIENT_SECRET'),
+      },
+    })
+    .then(response => {
+      Cypress.env('API_TOKEN', {
+        accessToken: response.body.access_token,
+        expiresAt: Date.now() + response.body.expires_in * 1000,
+      })
+      return response.body.access_token
+    })
+}
+
+export const createAssessment = (data = null) => {
+  const oasysAssessmentPk = uuid()
+  cy.log(`Creating assessment with OASys PK: ${oasysAssessmentPk}`)
+  getApiToken().then(apiToken => {
+    cy.request({
+      url: `${env('COORDINATOR_API_URL')}/oasys/create`,
+      method: 'POST',
+      auth: { bearer: apiToken },
+      body: {
+        oasysAssessmentPk,
+        planType: 'INITIAL',
+        userDetails: oasysUser,
+      },
+      retryOnNetworkFailure: false,
+    }).then(createResponse => {
+      Cypress.env('last_assessment', {
+        assessmentId: createResponse.body.sanAssessmentId,
+        oasysAssessmentPk,
+      } as AssessmentContext)
+      if (data) {
+        cy.request({
+          url: `${env('SBNA_API_URL')}/assessment/${createResponse.body.sanAssessmentId}/answers`,
+          method: 'POST',
+          auth: { bearer: apiToken },
+          body: {
+            answersToAdd: data.assessment,
+            userDetails: {
+              id: 'cypress',
+              name: 'Cypress User',
+              type: 'SAN',
+            },
+          },
+          retryOnNetworkFailure: false,
+        })
+      }
+    })
+  })
+}
+
+export const enterAssessment = (
+  accessMode: AccessMode = AccessMode.READ_WRITE,
+  assessmentContextOverride: AssessmentContext = {},
+  completePrivacyDeclaration: boolean = true,
+) => {
+  const assessment: AssessmentContext = {
+    ...env('last_assessment'),
+    ...assessmentContextOverride,
+  }
+
+  cy.log(`Entering assessment with OASys PK: ${assessment.oasysAssessmentPk}`)
+
+  cy.session(
+    `${accessMode.valueOf()}:${JSON.stringify(assessment)}`,
+    () => {
+      getApiToken().then(apiToken => {
+        cy.request({
+          url: `${env('ARNS_HANDOVER_URL')}/handover`,
+          method: 'POST',
+          auth: { bearer: apiToken },
+          body: {
+            oasysAssessmentPk: assessment.oasysAssessmentPk,
+            assessmentVersion: Number.isInteger(assessment.assessmentVersion) ? assessment.assessmentVersion : null,
+            user: {
+              identifier: oasysUser.id,
+              displayName: oasysUser.name,
+              accessMode: accessMode.valueOf(),
+              returnUrl: Cypress.env('OASYS_UI_URL'),
+            },
+            subjectDetails: {
+              crn: 'X123456',
+              pnc: '01/123456789A',
+              givenName: 'Sam',
+              familyName: 'Whitfield',
+              dateOfBirth: '1970-01-01',
+              gender: 0,
+              location: 'COMMUNITY',
+              ...(assessment.sexuallyMotivatedOffenceHistory && {
+                sexuallyMotivatedOffenceHistory: assessment.sexuallyMotivatedOffenceHistory,
+              }),
+            },
+          },
+          retryOnNetworkFailure: false,
+        }).then(otlResponse => {
+          cy.visit(`${otlResponse.body.handoverLink}?clientId=${env('ARNS_HANDOVER_CLIENT_ID')}`, {
+            retryOnNetworkFailure: false,
+          })
+        })
+      })
+    },
+    {
+      validate: () => {
+        cy.request({ url: '/', retryOnNetworkFailure: false }).its('status').should('eq', 200)
+      },
+    },
+  )
+}

--- a/integration_tests/support/index.ts
+++ b/integration_tests/support/index.ts
@@ -7,7 +7,7 @@ import {
   createSentencePlanWithVersions,
   lockPlan,
   openSentencePlan,
-  openSentencePlanAuth,
+  openSentencePlanHmppsAuth,
   removeGoalFromPlan,
 } from './commands/backend'
 import { checkAccessibility } from './commands/accessibility'
@@ -24,7 +24,7 @@ compareSnapshotCommand()
 
 // Handover/Auth
 Cypress.Commands.add('openSentencePlan', openSentencePlan)
-Cypress.Commands.add('openSentencePlanAuth', openSentencePlanAuth)
+Cypress.Commands.add('openSentencePlanAuth', openSentencePlanHmppsAuth)
 Cypress.Commands.add('createSentencePlan', createSentencePlan)
 Cypress.Commands.add('handleDataPrivacyScreen', handleDataPrivacyScreen)
 

--- a/integration_tests/support/index.ts
+++ b/integration_tests/support/index.ts
@@ -10,6 +10,7 @@ import {
   openSentencePlanHmppsAuth,
   removeGoalFromPlan,
 } from './commands/backend'
+import { createAssessment, enterAssessment } from './commands/backendSan'
 import { checkAccessibility } from './commands/accessibility'
 import 'cypress-axe'
 import { hasFeedbackLink } from './commands/feedback'
@@ -27,6 +28,10 @@ Cypress.Commands.add('openSentencePlan', openSentencePlan)
 Cypress.Commands.add('openSentencePlanAuth', openSentencePlanHmppsAuth)
 Cypress.Commands.add('createSentencePlan', createSentencePlan)
 Cypress.Commands.add('handleDataPrivacyScreen', handleDataPrivacyScreen)
+
+// SAN handover session check when viewing previous version
+Cypress.Commands.add('createAssessment', createAssessment)
+Cypress.Commands.add('enterAssessment', enterAssessment)
 
 // API
 Cypress.Commands.add('addGoalToPlan', addGoalToPlan)


### PR DESCRIPTION
The contents of backendSan.ts should be the same as in the SAN project. The change to the Cypress config was so that I didn't have to make the code here different to the original in SAN that it was copied from.

SAN also has a "create Assessment with previous versions" function, which would be the next function to copy across, and that should then be enough to be able to have a full end-to-end test which exercises this bug.