### PR TITLE
SP2-1649: Check privacy screen agreed

### DIFF
--- a/integration_tests/support/commands/backend.ts
+++ b/integration_tests/support/commands/backend.ts
@@ -144,9 +144,12 @@ export const openSentencePlan = (
     getApiToken().then(apiToken =>
       cy
         .request(createHandoverContext(apiToken, oasysAssessmentPk, accessMode, planVersion, crn))
-        .then(handoverResponse =>
-          cy.visit(`${handoverResponse.body.handoverLink}?clientId=${Cypress.env('ARNS_HANDOVER_CLIENT_ID')}`),
-        ),
+        .then(handoverResponse => {
+          cy.visit(`${handoverResponse.body.handoverLink}?clientId=${Cypress.env('ARNS_HANDOVER_CLIENT_ID')}`)
+          if (accessMode === AccessMode.READ_WRITE) {
+            cy.handleDataPrivacyScreen()
+          }
+        }),
     ),
   )
 

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -24,6 +24,7 @@ declare module 'express-session' {
     token: Token
     returnLink: string
     oauthLogin?: { nonce: string; crn: string; returnTo?: string }
+    hasAgreedPrivacyPolicy: boolean
   }
 }
 

--- a/server/middleware/privacyScreenMiddleware.test.ts
+++ b/server/middleware/privacyScreenMiddleware.test.ts
@@ -2,12 +2,15 @@ import mockReq from '../testutils/preMadeMocks/mockReq'
 import mockRes from '../testutils/preMadeMocks/mockRes'
 import checkPrivacyScreenAgreed from './privacyScreenMiddleware'
 import URLs from '../routes/URLs'
+import { AccessMode } from '../@types/SessionType'
 
 describe('checkPrivacyScreenAgreed', () => {
   it('should redirect to privacy screen if not already agreed', () => {
     const req = mockReq()
     const res = mockRes()
     const next = jest.fn()
+
+    req.services.sessionService.getAccessMode = jest.fn().mockReturnValue(AccessMode.READ_WRITE)
 
     const middleware = checkPrivacyScreenAgreed()
 
@@ -17,12 +20,28 @@ describe('checkPrivacyScreenAgreed', () => {
   })
 })
 
-it('should call next if agreed', () => {
+it('should call next if agreed and READ_WRITE', () => {
   const req = mockReq()
   const res = mockRes()
   const next = jest.fn()
 
   req.session.hasAgreedPrivacyPolicy = true
+  req.services.sessionService.getAccessMode = jest.fn().mockReturnValue(AccessMode.READ_WRITE)
+
+  const middleware = checkPrivacyScreenAgreed()
+
+  middleware(req, res, next)
+
+  expect(next).toHaveBeenCalled()
+})
+
+it('should call next if READ_ONLY', () => {
+  const req = mockReq()
+  const res = mockRes()
+  const next = jest.fn()
+
+  req.session.hasAgreedPrivacyPolicy = undefined
+  req.services.sessionService.getAccessMode = jest.fn().mockReturnValue(AccessMode.READ_ONLY)
 
   const middleware = checkPrivacyScreenAgreed()
 

--- a/server/middleware/privacyScreenMiddleware.test.ts
+++ b/server/middleware/privacyScreenMiddleware.test.ts
@@ -1,0 +1,32 @@
+import mockReq from '../testutils/preMadeMocks/mockReq'
+import mockRes from '../testutils/preMadeMocks/mockRes'
+import checkPrivacyScreenAgreed from './privacyScreenMiddleware'
+import URLs from '../routes/URLs'
+
+describe('checkPrivacyScreenAgreed', () => {
+  it('should redirect to privacy screen if not already agreed', () => {
+    const req = mockReq()
+    const res = mockRes()
+    const next = jest.fn()
+
+    const middleware = checkPrivacyScreenAgreed()
+
+    middleware(req, res, next)
+
+    expect(res.redirect).toHaveBeenCalledWith(URLs.DATA_PRIVACY)
+  })
+})
+
+it('should call next if agreed', () => {
+  const req = mockReq()
+  const res = mockRes()
+  const next = jest.fn()
+
+  req.session.hasAgreedPrivacyPolicy = true
+
+  const middleware = checkPrivacyScreenAgreed()
+
+  middleware(req, res, next)
+
+  expect(next).toHaveBeenCalled()
+})

--- a/server/middleware/privacyScreenMiddleware.ts
+++ b/server/middleware/privacyScreenMiddleware.ts
@@ -1,10 +1,11 @@
 import { NextFunction, Request, Response } from 'express'
 import 'reflect-metadata'
 import URLs from '../routes/URLs'
+import { AccessMode } from '../@types/SessionType'
 
 export default function checkPrivacyScreenAgreed() {
   return (req: Request, res: Response, next: NextFunction) => {
-    if (req.session.hasAgreedPrivacyPolicy) {
+    if (req.session.hasAgreedPrivacyPolicy || req.services.sessionService.getAccessMode() === AccessMode.READ_ONLY) {
       return next()
     }
     return res.redirect(URLs.DATA_PRIVACY)

--- a/server/middleware/privacyScreenMiddleware.ts
+++ b/server/middleware/privacyScreenMiddleware.ts
@@ -1,0 +1,12 @@
+import { NextFunction, Request, Response } from 'express'
+import 'reflect-metadata'
+import URLs from '../routes/URLs'
+
+export default function checkPrivacyScreenAgreed() {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (req.session.hasAgreedPrivacyPolicy) {
+      return next()
+    }
+    return res.redirect(URLs.DATA_PRIVACY)
+  }
+}

--- a/server/routes/planOverview/PlanOverviewController.test.ts
+++ b/server/routes/planOverview/PlanOverviewController.test.ts
@@ -69,6 +69,8 @@ describe('PlanOverviewController', () => {
     res = mockRes()
     next = jest.fn()
 
+    req.session.hasAgreedPrivacyPolicy = true
+
     controller = new PlanOverviewController()
   })
 
@@ -137,6 +139,9 @@ describe('PlanOverviewController', () => {
           type: 'future',
           status: 'removed',
         },
+        session: {
+          hasAgreedPrivacyPolicy: true,
+        },
       })
 
       await runMiddlewareChain(controller.get, req, res, next)
@@ -158,6 +163,9 @@ describe('PlanOverviewController', () => {
         query: {
           type: 'cheese',
           status: 'sausage',
+        },
+        session: {
+          hasAgreedPrivacyPolicy: true,
         },
       })
 

--- a/server/routes/planOverview/PlanOverviewController.ts
+++ b/server/routes/planOverview/PlanOverviewController.ts
@@ -13,6 +13,7 @@ import { HttpError } from '../../utils/HttpError'
 import { PlanAgreementStatus, PlanType } from '../../@types/PlanType'
 import { AuditEvent } from '../../services/auditService'
 import { AccessMode } from '../../@types/SessionType'
+import checkPrivacyScreenAgreed from '../../middleware/privacyScreenMiddleware'
 
 export default class PlanOverviewController {
   plan: PlanType
@@ -129,6 +130,7 @@ export default class PlanOverviewController {
 
   get = [
     requireAccessMode(AccessMode.READ_ONLY),
+    checkPrivacyScreenAgreed(),
     transformRequest({ query: PlanOverviewQueryModel }),
     validateRequest(),
     this.validatePlan,

--- a/server/routes/privacy-screen/PrivacyScreenController.ts
+++ b/server/routes/privacy-screen/PrivacyScreenController.ts
@@ -39,6 +39,11 @@ export default class PrivacyScreenController {
     return next()
   }
 
+  private setHasAgreedPrivacyPolicy = (req: Request, res: Response, next: NextFunction) => {
+    req.session.hasAgreedPrivacyPolicy = true
+    return next()
+  }
+
   get = [requireAccessMode(AccessMode.READ_WRITE), this.render]
 
   post = [
@@ -48,6 +53,7 @@ export default class PrivacyScreenController {
     }),
     validateRequest(),
     this.handleValidationErrors,
+    this.setHasAgreedPrivacyPolicy,
     this.redirect,
   ]
 }


### PR DESCRIPTION
-  Redirects to the privacy screen if accessing `/plan` without having agreed.

- Prevents user from clicking on 'Sentence Plan' on the page header to get to the plan, avoiding agreeing to the privacy statement.